### PR TITLE
modal 컴포넌트 명칭 명확한 명칭으로 변경

### DIFF
--- a/src/api/watchlist/queries/useWatchlistItemAddMutation.ts
+++ b/src/api/watchlist/queries/useWatchlistItemAddMutation.ts
@@ -3,10 +3,12 @@ import { postWatchlistItem } from "..";
 import { watchlistKeys } from "./queryKeys";
 
 type Props = {
-  onCloseModal: () => void;
+  onCloseDialog: () => void;
 };
 
-export default function useWatchlistItemAddMutation({ onCloseModal }: Props) {
+export default function useWatchlistItemAddMutation({
+  onCloseDialog: onCloseDialog,
+}: Props) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -16,7 +18,7 @@ export default function useWatchlistItemAddMutation({ onCloseModal }: Props) {
       queryClient.invalidateQueries({
         queryKey: watchlistKeys.list().queryKey,
       });
-      onCloseModal();
+      onCloseDialog();
     },
 
     // TODO: error handling

--- a/src/api/watchlist/queries/useWatchlistItemDeleteMutation.ts
+++ b/src/api/watchlist/queries/useWatchlistItemDeleteMutation.ts
@@ -3,12 +3,12 @@ import { deleteWatchlistItem } from "..";
 import { watchlistKeys } from "./queryKeys";
 
 type Props = {
-  onCloseModal: () => void;
+  onCloseDialog: () => void;
   tickerSymbol: string;
 };
 
 export default function useWatchlistItemDeleteMutation({
-  onCloseModal,
+  onCloseDialog: onCloseDialog,
   tickerSymbol,
 }: Props) {
   const queryClient = useQueryClient();
@@ -20,7 +20,7 @@ export default function useWatchlistItemDeleteMutation({
       queryClient.invalidateQueries({
         queryKey: watchlistKeys.list().queryKey,
       });
-      onCloseModal();
+      onCloseDialog();
     },
   });
 }

--- a/src/components/BaseDialog.tsx
+++ b/src/components/BaseDialog.tsx
@@ -9,7 +9,12 @@ type Props = {
   onClose: () => void;
 };
 
-export default function BaseModal({ style, children, isOpen, onClose }: Props) {
+export default function BaseDialog({
+  style,
+  children,
+  isOpen,
+  onClose,
+}: Props) {
   return (
     <Modal open={isOpen} onClose={onClose}>
       <Box sx={{ ...baseStyle, ...style }}>{children}</Box>

--- a/src/components/ConfirmAlert.tsx
+++ b/src/components/ConfirmAlert.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@mui/material";
 import styled from "styled-components";
-import BaseModal from "./BaseModal";
+import BaseDialog from "./BaseDialog";
 
 type Props = {
   isOpen: boolean;
@@ -23,7 +23,7 @@ export default function ConfirmAlert({
   };
 
   return (
-    <BaseModal style={ConfirmAlertStyle} isOpen={isOpen} onClose={onClose}>
+    <BaseDialog style={ConfirmAlertStyle} isOpen={isOpen} onClose={onClose}>
       <Wrapper>
         <Title>{title}</Title>
         <Body>{content}</Body>
@@ -32,7 +32,7 @@ export default function ConfirmAlert({
           <Button onClick={onConfirmAlertClose}>확인</Button>
         </ButtonWrapper>
       </Wrapper>
-    </BaseModal>
+    </BaseDialog>
   );
 }
 

--- a/src/components/Portfolio/PortfolioDialog.tsx
+++ b/src/components/Portfolio/PortfolioDialog.tsx
@@ -1,7 +1,7 @@
 import { PortfolioDetails } from "@api/portfolio";
 import usePortfolioAddMutation from "@api/portfolio/queries/usePortfolioAddMutation";
 import usePortfolioEditMutation from "@api/portfolio/queries/usePortfolioEditMutation";
-import BaseModal from "@components/BaseModal";
+import BaseDialog from "@components/BaseDialog";
 import useText from "@components/hooks/useText";
 import {
   Button,
@@ -23,7 +23,7 @@ type Props = {
 };
 
 // TODO: Refactoring 시급!
-export default function PortfolioModal({
+export default function PortfolioDialog({
   isOpen,
   onClose,
   portfolioDetails,
@@ -174,7 +174,7 @@ export default function PortfolioModal({
   }, [isEditSuccess, isEditError, onClose]);
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose}>
+    <BaseDialog isOpen={isOpen} onClose={onClose}>
       <Wrapper>
         <main />
         <Header>포트폴리오 {isEditMode ? `수정` : `추가`}</Header>
@@ -256,7 +256,7 @@ export default function PortfolioModal({
           <SubmitButton onClick={onSubmit}>저장</SubmitButton>
         </ButtonWrapper>
       </Wrapper>
-    </BaseModal>
+    </BaseDialog>
   );
 }
 

--- a/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingAddDialog.tsx
+++ b/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingAddDialog.tsx
@@ -1,5 +1,5 @@
 import usePortfolioHoldingAddMutation from "@api/portfolio/queries/usePortfolioHoldingAddMutation";
-import BaseModal from "@components/BaseModal";
+import BaseDialog from "@components/BaseDialog";
 import SearchBar from "@components/SearchBar/SearchBar";
 
 type Props = {
@@ -8,7 +8,7 @@ type Props = {
   onClose: () => void;
 };
 
-export default function PortfolioHoldingAddModal({
+export default function PortfolioHoldingAddDialog({
   portfolioId,
   isOpen,
   onClose,
@@ -28,13 +28,13 @@ export default function PortfolioHoldingAddModal({
   };
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose}>
+    <BaseDialog isOpen={isOpen} onClose={onClose}>
       <>
         <SearchBar>
           <SearchBar.Input />
           <SearchBar.SearchList onItemClick={addStockToPortfolio} />
         </SearchBar>
       </>
-    </BaseModal>
+    </BaseDialog>
   );
 }

--- a/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingLots.tsx
+++ b/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingLots.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 import PortfolioHoldingLotRow from "./PortfolioHoldingLotRow";
-import PortfolioHoldingPurchaseAddModal from "./PortfolioHoldingPurchaseAddModal";
+import PortfolioHoldingPurchaseAddDialog from "./PortfolioHoldingPurchaseAddDialog";
 
 type Props = {
   portfolioId: number;
@@ -23,11 +23,11 @@ export default function PortfolioHoldingLots({
   portfolioHoldingId,
   purchaseHistory,
 }: Props) {
-  const [isAddHoldingPurchaseModalOpen, setIsAddHoldingPurchaseModalOpen] =
+  const [isAddHoldingPurchaseDialogOpen, setIsAddHoldingPurchaseDialogOpen] =
     useState(false);
 
   const onAddPurchaseClick = () => {
-    setIsAddHoldingPurchaseModalOpen(true);
+    setIsAddHoldingPurchaseDialogOpen(true);
   };
 
   return (
@@ -63,9 +63,9 @@ export default function PortfolioHoldingLots({
         </TableFooter>
       </Table>
 
-      <PortfolioHoldingPurchaseAddModal
-        isOpen={isAddHoldingPurchaseModalOpen}
-        onClose={() => setIsAddHoldingPurchaseModalOpen(false)}
+      <PortfolioHoldingPurchaseAddDialog
+        isOpen={isAddHoldingPurchaseDialogOpen}
+        onClose={() => setIsAddHoldingPurchaseDialogOpen(false)}
         portfolioId={portfolioId}
         portfolioHoldingId={portfolioHoldingId}
       />

--- a/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingPurchaseAddDialog.tsx
+++ b/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingPurchaseAddDialog.tsx
@@ -1,5 +1,5 @@
 import usePortfolioHoldingPurchaseAddMutation from "@api/portfolio/queries/usePortfolioHoldingPurchaseAddMutation";
-import BaseModal from "@components/BaseModal";
+import BaseDialog from "@components/BaseDialog";
 import { Button, FormControl, Input, InputLabel } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
@@ -12,7 +12,7 @@ type Props = {
   portfolioHoldingId: number;
 };
 
-export default function PortfolioHoldingPurchaseAddModal({
+export default function PortfolioHoldingPurchaseAddDialog({
   isOpen,
   onClose,
   portfolioId,
@@ -46,7 +46,7 @@ export default function PortfolioHoldingPurchaseAddModal({
   };
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose}>
+    <BaseDialog isOpen={isOpen} onClose={onClose}>
       <div>종목 매입 이력 추가</div>
       <form onSubmit={onSubmit}>
         <FormControl>
@@ -92,6 +92,6 @@ export default function PortfolioHoldingPurchaseAddModal({
 
         <Button type="submit">매입 이력 추가</Button>
       </form>
-    </BaseModal>
+    </BaseDialog>
   );
 }

--- a/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingRow.tsx
+++ b/src/components/Portfolio/PortfolioHoldings/PortfolioHoldingRow.tsx
@@ -44,10 +44,10 @@ export default function PortfolioHoldingRow({
     usePortfolioHoldingDeleteMutation(portfolioId);
 
   const [isRowOpen, setIsRowOpen] = useState(false);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   const onDeleteClick = () => {
-    setIsDeleteModalOpen(true);
+    setIsDeleteDialogOpen(true);
   };
 
   const onConfirmDelete = () => {
@@ -138,10 +138,10 @@ export default function PortfolioHoldingRow({
       </HoldingLotRow>
 
       <ConfirmAlert
-        isOpen={isDeleteModalOpen}
+        isOpen={isDeleteDialogOpen}
         title="종목 삭제"
         content="종목을 삭제하시겠습니까?"
-        onClose={() => setIsDeleteModalOpen(false)}
+        onClose={() => setIsDeleteDialogOpen(false)}
         onConfirm={onConfirmDelete}
       />
     </>

--- a/src/components/Portfolio/PortfolioOverview.tsx
+++ b/src/components/Portfolio/PortfolioOverview.tsx
@@ -2,7 +2,7 @@ import { PortfolioDetails } from "@api/portfolio";
 import usePortfolioDeleteMutation from "@api/portfolio/queries/usePortfolioDeleteMutation";
 import tossLogo from "@assets/images/Toss_Symbol_Primary.png";
 import ConfirmAlert from "@components/ConfirmAlert";
-import PortfolioModal from "@components/Portfolio/PortfolioModal";
+import PortfolioDialog from "@components/Portfolio/PortfolioDialog";
 import ToggleSwitch from "@components/ToggleSwitch";
 import { Button } from "@mui/material";
 import { useState } from "react";
@@ -21,19 +21,19 @@ export default function PortfolioOverview({ data }: Props) {
 
   const [isTargetSwitchChecked, setIsTargetSwitchChecked] = useState(true);
   const [isLossSwitchChecked, setIsLossSwitchChecked] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   const onPortfolioEdit = () => {
-    setIsModalOpen(true);
+    setIsDialogOpen(true);
   };
 
   const onPortfolioRemove = () => {
     setIsConfirmOpen(true);
   };
 
-  const onModalClose = () => {
-    setIsModalOpen(false);
+  const onDialogClose = () => {
+    setIsDialogOpen(false);
   };
 
   const onConfirmAlertClose = () => {
@@ -54,10 +54,10 @@ export default function PortfolioOverview({ data }: Props) {
 
   return (
     <StyledPortfolioOverview>
-      {isModalOpen && (
-        <PortfolioModal
-          isOpen={isModalOpen}
-          onClose={onModalClose}
+      {isDialogOpen && (
+        <PortfolioDialog
+          isOpen={isDialogOpen}
+          onClose={onDialogClose}
           portfolioDetails={data}
         />
       )}

--- a/src/components/Watchlist/Watchlist.tsx
+++ b/src/components/Watchlist/Watchlist.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { List, arrayMove } from "react-movable";
 import styled from "styled-components";
 import WatchlistItem from "./WatchlistItem";
-import WatchlistItemAddModal from "./WatchlistItemAddModal";
+import WatchlistItemAddDialog from "./WatchlistItemAddDialog";
 import WatchlistItemDeleteAlert from "./WatchlistItemDeleteAlert";
 
 export default function Watchlist() {
@@ -15,17 +15,17 @@ export default function Watchlist() {
   const [watchlist, setWatchlist] = useState<WatchlistItemType[]>(
     watchlistData ?? []
   );
-  const [isAddItemModalOpen, setIsAddItemModalOpen] = useState(false);
+  const [isAddItemDialogOpen, setIsAddItemDialogOpen] = useState(false);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
   const [currentSelectedTickerSymbol, setCurrentSelectedTickerSymbol] =
     useState(0);
 
   const onPlusButtonClick = () => {
-    setIsAddItemModalOpen(true);
+    setIsAddItemDialogOpen(true);
   };
 
-  const onItemAddModalClose = () => {
-    setIsAddItemModalOpen(false);
+  const onItemAddDialogClose = () => {
+    setIsAddItemDialogOpen(false);
   };
 
   const onDeleteButtonDown = (tickerSymbol: number) => {
@@ -71,9 +71,9 @@ export default function Watchlist() {
       />
       <PlusButton onClick={onPlusButtonClick}>+</PlusButton>
 
-      <WatchlistItemAddModal
-        isOpen={isAddItemModalOpen}
-        onClose={onItemAddModalClose}
+      <WatchlistItemAddDialog
+        isOpen={isAddItemDialogOpen}
+        onClose={onItemAddDialogClose}
       />
 
       <WatchlistItemDeleteAlert

--- a/src/components/Watchlist/WatchlistItemAddDialog.tsx
+++ b/src/components/Watchlist/WatchlistItemAddDialog.tsx
@@ -1,5 +1,5 @@
 import useWatchlistItemAddMutation from "@api/watchlist/queries/useWatchlistItemAddMutation";
-import BaseModal from "@components/BaseModal";
+import BaseDialog from "@components/BaseDialog";
 import SearchBar from "@components/SearchBar/SearchBar";
 
 type Props = {
@@ -7,9 +7,9 @@ type Props = {
   onClose: () => void;
 };
 
-export default function WatchlistItemAddModal({ isOpen, onClose }: Props) {
+export default function WatchlistItemAddDialog({ isOpen, onClose }: Props) {
   const { mutate: watchlistItemAddMutate } = useWatchlistItemAddMutation({
-    onCloseModal: onClose,
+    onCloseDialog: onClose,
   });
 
   const addItemToWatchlist = (tickerSymbol: string) => {
@@ -17,13 +17,13 @@ export default function WatchlistItemAddModal({ isOpen, onClose }: Props) {
   };
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose}>
+    <BaseDialog isOpen={isOpen} onClose={onClose}>
       <>
         <SearchBar>
           <SearchBar.Input />
           <SearchBar.SearchList onItemClick={addItemToWatchlist} />
         </SearchBar>
       </>
-    </BaseModal>
+    </BaseDialog>
   );
 }

--- a/src/components/Watchlist/WatchlistItemDeleteAlert.tsx
+++ b/src/components/Watchlist/WatchlistItemDeleteAlert.tsx
@@ -1,5 +1,5 @@
 import useWatchlistItemDeleteMutation from "@api/watchlist/queries/useWatchlistItemDeleteMutation";
-import BaseModal from "@components/BaseModal";
+import BaseDialog from "@components/BaseDialog";
 import styled from "styled-components";
 
 type Props = {
@@ -15,7 +15,7 @@ export default function WatchlistItemDeleteAlert({
 }: Props) {
   const { mutate: watchlistItemDeleteMutate } = useWatchlistItemDeleteMutation({
     tickerSymbol: String(currentSelectedTickerSymbol),
-    onCloseModal: onClose,
+    onCloseDialog: onClose,
   });
 
   const deleteItemFromWatchlist = () => {
@@ -23,11 +23,11 @@ export default function WatchlistItemDeleteAlert({
   };
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose}>
+    <BaseDialog isOpen={isOpen} onClose={onClose}>
       <div>진짜로 삭제하시겠습니까?</div>
       <Button onClick={deleteItemFromWatchlist}>예</Button>
       <Button onClick={onClose}>아니오</Button>
-    </BaseModal>
+    </BaseDialog>
   );
 }
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,6 @@
 import { PortfolioItem } from "@api/portfolio";
 import usePortfolioListQuery from "@api/portfolio/queries/usePortfolioListQuery";
-import PortfolioModal from "@components/Portfolio/PortfolioModal";
+import PortfolioDialog from "@components/Portfolio/PortfolioDialog";
 import { UserContext } from "@context/UserContext";
 import { Button } from "@mui/material";
 import { useContext, useState } from "react";
@@ -20,7 +20,8 @@ export default function Header() {
 
   const { data: portfolioList } = usePortfolioListQuery();
 
-  const [isPortfolioAddModalOpen, setIsPortfolioAddModalOpen] = useState(false);
+  const [isPortfolioAddDialogOpen, setIsPortfolioAddDialogOpen] =
+    useState(false);
 
   const navItems = [
     {
@@ -42,7 +43,7 @@ export default function Header() {
   );
 
   const onPortfolioAddClick = () => {
-    setIsPortfolioAddModalOpen(true);
+    setIsPortfolioAddDialogOpen(true);
   };
 
   const moveToStockPage = (tickerSymbol: string) => {
@@ -60,10 +61,10 @@ export default function Header() {
   return (
     <>
       <StyledHeader>
-        {isPortfolioAddModalOpen && (
-          <PortfolioModal
-            isOpen={isPortfolioAddModalOpen}
-            onClose={() => setIsPortfolioAddModalOpen(false)}
+        {isPortfolioAddDialogOpen && (
+          <PortfolioDialog
+            isOpen={isPortfolioAddDialogOpen}
+            onClose={() => setIsPortfolioAddDialogOpen(false)}
           />
         )}
         <HeaderTop>

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -4,7 +4,7 @@ import usePortfolioDetailsQuery from "@api/portfolio/queries/usePortfolioDetails
 import plusIcon from "@assets/icons/plus.svg";
 import DividendBarChart from "@components/Portfolio/DividendBarChart";
 import HoldingsPieChart from "@components/Portfolio/HoldingsPieChart";
-import PortfolioHoldingAddModal from "@components/Portfolio/PortfolioHoldings/PortfolioHoldingAddModal";
+import PortfolioHoldingAddDialog from "@components/Portfolio/PortfolioHoldings/PortfolioHoldingAddDialog";
 import PortfolioHoldingsTable from "@components/Portfolio/PortfolioHoldings/PortfolioHoldingsTable";
 import PortfolioOverview from "@components/Portfolio/PortfolioOverview";
 import SectorBar from "@components/Portfolio/SectorBar";
@@ -23,7 +23,7 @@ export default function PortfolioPage() {
   const { data: portfolio, isLoading: isPortfolioDetailsLoading } =
     usePortfolioDetailsQuery(Number(id));
 
-  const [isAddHoldingModalOpen, setIsAddHoldingModalOpen] = useState(false);
+  const [isAddHoldingDialogOpen, setIsAddHoldingDialogOpen] = useState(false);
 
   const { onConnect } = useStompSubscription<Portfolio>({
     brokerURL: `${BASE_API_URL_WS}/portfolio`,
@@ -47,7 +47,7 @@ export default function PortfolioPage() {
   }, [portfolio, onConnect]);
 
   const onAddHoldingButtonClick = () => {
-    setIsAddHoldingModalOpen(true);
+    setIsAddHoldingDialogOpen(true);
   };
 
   // TODO: Handle loading
@@ -104,10 +104,10 @@ export default function PortfolioPage() {
 
       <Footer />
 
-      <PortfolioHoldingAddModal
+      <PortfolioHoldingAddDialog
         portfolioId={Number(id)}
-        isOpen={isAddHoldingModalOpen}
-        onClose={() => setIsAddHoldingModalOpen(false)}
+        isOpen={isAddHoldingDialogOpen}
+        onClose={() => setIsAddHoldingDialogOpen(false)}
       />
     </StyledPortfolioPage>
   );


### PR DESCRIPTION
## 수정한 것
- `Modal` -> `Dialog`
  - Modal은 외부 상호작용을 차단하고 특정 레이어에 집중하기 위한 레이어를 모두 포함한 명칭입니다.
    - 즉, Dialog가 Modal에 포함되는 명칭입니다.
  - Dialog는 유저에게 입력, 버튼 등으로 추가 적인 액션을 받는데 적합합니다.
- `ConfirmAlert` -> `ConfirmDialog`
  - 위 명칭 변경은 하지 않았습니다. 이유는 Alert의 경우 유저에게 경고를 주고 특정 액션의 진행 여부를 판단하는것 이라 생각 하기 때문에 Dialog 보다 적합하다고 생각 했습니다.

## To Reviewers
- MUI에서 제공하는 `Dialog` 컴포넌트를 이용해서 `BaseDialog`를 구현하려 했는데 커스터마이징이 어렵기도 하고 오히려 DX적으로 불편한 부분이 더 많이 생겨서 `Modal` 컴포넌트를 이용해서 `baseDialog`를 구현한 컴포넌트로 된 것 같습니다.
  - Modal이 Dialog의 상위 개념이기 때문에 저는 괜찮다 판단했는데 두분 의견 남겨주세요.
- 평소에 Modal이라고 자주 사용하던 컴포넌트를 갑자기 모두 Dialog로 변경하며 익숙하지 않을 수 있을 것 같습니다.
  - 이 부분에 있어서 명칭은 정확해 졌으나 갑작스런 명칭 변경으로 개발하는 입장에서 불편하거나 익숙하지 못한 부분이 생길 것 같아 조금 걱정이 있습니다.
  - 항상 Modal이라 부르던 부분을 갑자기 Dialog라고 하려니 조금 어색하네요
