### PR TITLE
[refactor] portfolio dialog

### DIFF
--- a/src/components/Portfolio/PortfolioDialog.tsx
+++ b/src/components/Portfolio/PortfolioDialog.tsx
@@ -11,7 +11,11 @@ import {
   Select,
   SelectChangeEvent,
 } from "@mui/material";
-import { calculateRate, calculateValue } from "@utils/calculations";
+import {
+  calculateLossRate,
+  calculateRate,
+  calculateValue,
+} from "@utils/calculations";
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
@@ -22,7 +26,6 @@ type Props = {
   portfolioDetails?: PortfolioDetails;
 };
 
-// TODO: Refactoring 시급!
 export default function PortfolioDialog({
   isOpen,
   onClose,
@@ -111,9 +114,7 @@ export default function PortfolioDialog({
     const valueNumber = Number(value);
 
     onMaximumLossChange(value);
-    onMaximumLossRateChange(
-      (((budgetNumber - valueNumber) / budgetNumber) * 100).toString()
-    );
+    onMaximumLossRateChange(calculateLossRate(budgetNumber, valueNumber));
   });
 
   const maximumLossRateHandler = changeIfNumberOnly((value: string) => {
@@ -135,12 +136,8 @@ export default function PortfolioDialog({
     };
 
     if (isEditMode) {
-      // TODO : 포트폴리오 수정
-
       editMutate({ portfolioId: Number(id), body: body });
     } else {
-      // TODO : 포트폴리오 추가
-
       addMutate(body);
     }
   };
@@ -155,12 +152,12 @@ export default function PortfolioDialog({
     }
   }, [
     budget,
-    clearInputs,
+    targetGain,
     isBudgetEmpty,
     maximumLoss,
+    clearInputs,
     onMaximumLossHandler,
     onTargetGainHandler,
-    targetGain,
   ]);
 
   useEffect(() => {
@@ -172,6 +169,33 @@ export default function PortfolioDialog({
       // TODO toast
     }
   }, [isEditSuccess, isEditError, onClose]);
+
+  const isFormValid = () => {
+    if (
+      !name ||
+      !budget ||
+      !targetGain ||
+      !targetReturnRate ||
+      !maximumLoss ||
+      !maximumLossRate
+    ) {
+      return false;
+    }
+
+    if (isEditMode) {
+      return (
+        portfolioDetails?.securitiesFirm !== securitiesFirm ||
+        portfolioDetails?.name !== name ||
+        portfolioDetails?.budget !== Number(budget) ||
+        portfolioDetails?.targetGain !== Number(targetGain) ||
+        portfolioDetails?.targetReturnRate !== Number(targetReturnRate) ||
+        portfolioDetails?.maximumLoss !== Number(maximumLoss) ||
+        portfolioDetails?.maximumLossRate !== Number(maximumLossRate)
+      );
+    }
+
+    return true;
+  };
 
   return (
     <BaseDialog isOpen={isOpen} onClose={onClose}>
@@ -251,9 +275,10 @@ export default function PortfolioDialog({
             </InputWrapper>
           </Row>
         </Body>
-        {/* TODO : submitButton disabled 조건식 추가 */}
         <ButtonWrapper>
-          <SubmitButton onClick={onSubmit}>저장</SubmitButton>
+          <SubmitButton onClick={onSubmit} disabled={!isFormValid()}>
+            저장
+          </SubmitButton>
         </ButtonWrapper>
       </Wrapper>
     </BaseDialog>

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,9 +1,25 @@
 export const calculateRate = (num1: number, num2: number) => {
-  return ((num1 - num2) / num2) * 100;
+  const rate = ((num1 - num2) / num2) * 100;
+
+  return formatValue(rate);
+};
+
+export const calculateLossRate = (num1: number, num2: number) => {
+  const rate = ((num1 - num2) / num1) * 100;
+
+  return formatValue(rate);
 };
 
 export const calculateValue = (rate: number, base: number) => {
   const value = base + (rate / 100) * base;
 
-  return Math.floor(value) === value ? value.toString() : value.toFixed(2);
+  return formatValue(value);
 };
+
+function formatValue(value: number) {
+  if (value % 1 === 0) {
+    return value.toString();
+  } else {
+    return parseFloat(value.toFixed(2)).toString();
+  }
+}


### PR DESCRIPTION
## 구현한 것
- 수정, 추가 로직이 추가 되었으니 TODO 지우기
- Button disabled 조건식 추가하기
- Input 소수점 2자리 문제 해결하기

## To Reviewers
- `portfolioDialog` 컴포넌트가 사이즈가 너무 커서 추가/수정을 분리하려 했는데 분리가 오히려 복잡도를 상승 시키는 느낌이라 분리하지 않았습니다.
- 이유는 `portfolioDialog`의 코드 약 90% 추가/수정 모두 필요한 중복 코드이고 분리한다면 약 10%의 코드만 분리가 가능 할 것 같습니다.
  - 추가 또는 수정에 대한 api 호출
  - useText의 초기 값을 undefined 또는 수정을 위한 기존 값인 `portfolioDetails`의 전달
  - submit button diabled 로직
- 이렇게 분리를 한다면 10%의 코드(약 50줄)을 줄이기 위해서 `공통 로직 파일` 1개, `추가, 수정 파일` 각각 1개씩 총 3개가 된다면 오히려 복잡도가 올라가며 불가피하게 중복도 조금 생기게 되어 리팩터링이 더 힘들게 될 것 같아 분리하지 않았습니다.
- 추후에 리팩터링을 함께 진행해도 좋을 것 같습니다🙏