### PR TITLE
custom Toast 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 npm test && npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "^18.2.0",
         "react-movable": "^3.0.4",
         "react-router-dom": "^6.16.0",
+        "react-toastify": "^9.1.3",
         "react-verification-input": "^3.3.1",
         "recharts": "^2.9.0",
         "styled-components": "^6.1.0"
@@ -9078,6 +9079,26 @@
       "peerDependencies": {
         "react": ">=15.0.0",
         "react-dom": ">=15.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-toastify/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^18.2.0",
     "react-movable": "^3.0.4",
     "react-router-dom": "^6.16.0",
+    "react-toastify": "^9.1.3",
     "react-verification-input": "^3.3.1",
     "recharts": "^2.9.0",
     "styled-components": "^6.1.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { CustomToastContainer } from "@components/hooks/Toast";
 import { UserContext } from "@context/UserContext";
 import { useContext } from "react";
 import { RouterProvider } from "react-router-dom";
@@ -12,7 +13,7 @@ export default function App() {
   return (
     <ThemeProvider theme={designSystem}>
       <GlobalStyles />
-
+      <CustomToastContainer />
       <StyledApp>
         <RouterProvider router={router(user)} />
       </StyledApp>

--- a/src/components/hooks/Toast.tsx
+++ b/src/components/hooks/Toast.tsx
@@ -1,0 +1,57 @@
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import styled from "styled-components";
+
+// TODO : 디자인에 맞게 커스터마이징
+export const CustomToastContainer = styled(ToastContainer)`
+  .Toastify__toast {
+  }
+
+  .Toastify__toast-icon {
+  }
+
+  .Toastify__toast--info {
+  }
+
+  .Toastify__toast--success {
+  }
+
+  .Toastify__toast--error {
+  }
+
+  .Toastify__toast--warning {
+  }
+`;
+
+type Props = {
+  type: "success" | "error" | "info" | "warning";
+  message?: string;
+  autoCloseDelay?: number;
+  toastPosition?:
+    | "top-left"
+    | "top-right"
+    | "top-center"
+    | "bottom-left"
+    | "bottom-right"
+    | "bottom-center";
+};
+
+export function useShowToast({
+  type,
+  message,
+  autoCloseDelay = 5000,
+  toastPosition = "top-right",
+}: Props) {
+  const toastOption = { position: toastPosition, autoClose: autoCloseDelay };
+
+  switch (type) {
+    case "success":
+      return () => toast.success(message || "성공!", toastOption);
+    case "error":
+      return () => toast.error(message || "에러!", toastOption);
+    case "warning":
+      return () => toast.warning(message || "경고!", toastOption);
+    case "info":
+      return () => toast.info(message || "정보!", toastOption);
+  }
+}

--- a/src/components/hooks/Toast.tsx
+++ b/src/components/hooks/Toast.tsx
@@ -26,7 +26,7 @@ export const CustomToastContainer = styled(ToastContainer)`
 type Props = {
   type: "success" | "error" | "info" | "warning";
   message?: string;
-  autoCloseDelay?: number;
+  autoCloseDelay?: number | false;
   toastPosition?:
     | "top-left"
     | "top-right"
@@ -42,16 +42,13 @@ export function useShowToast({
   autoCloseDelay = 5000,
   toastPosition = "top-right",
 }: Props) {
-  const toastOption = { position: toastPosition, autoClose: autoCloseDelay };
+  const toastOptions = { position: toastPosition, autoClose: autoCloseDelay };
+  const messages = {
+    success: "성공!",
+    error: "에러!",
+    warning: "경고!",
+    info: "정보!",
+  };
 
-  switch (type) {
-    case "success":
-      return () => toast.success(message || "성공!", toastOption);
-    case "error":
-      return () => toast.error(message || "에러!", toastOption);
-    case "warning":
-      return () => toast.warning(message || "경고!", toastOption);
-    case "info":
-      return () => toast.info(message || "정보!", toastOption);
-  }
+  return () => toast[type](message || messages[type], toastOptions);
 }


### PR DESCRIPTION
## 구현한 것
- react-toastify 라이브러리 추가 했습니다.
  - react-hot-toast 보다 기능도 다양하고 문서도 더 깔끔하다고 판단해서 선택했습니다.
- CustomToastContainer은 디자인이 추가되면 커스터마이징 하면 될 것 같아 styled로만 만들어 놓았습니다.
- useShowToast hook 구현 했습니다.
  - type은 다음과 같습니다
  ```
  type Props = {
    type: "success" | "error" | "info" | "warning";
    message?: string;
    autoCloseDelay?: number | false;
    toastPosition?:
      | "top-left"
      | "top-right"
      | "top-center"
      | "bottom-left"
      | "bottom-right"
      | "bottom-center";
  }
  ```

## 기타
- 우선 사용처를 생각해 놓은게 명확하지 않아서 적용은 하지 않았습니다.
- 알림과 함께 사용할 수 있어 보이는 addOn이 있네요
  - https://fkhadra.github.io/react-toastify/addons/use-notification-center
