### PR TITLE
dropdown 리팩터링

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,7 +13,7 @@ import { NavBar } from "../NavBar";
 import SearchBar from "../SearchBar/SearchBar";
 import TVTickerTapeWidget from "../TradingViewWidgets/TVTickerTape";
 import UserControls from "../common/UserControls";
-import Dropdown from "./Dropdown";
+import { PortfoliosDropdown } from "./PortfoliosDropdown";
 
 export default function Header() {
   const navigate = useNavigate();
@@ -76,26 +76,10 @@ export default function Header() {
               FineAnts
             </StyledBrandIdentity>
             <NavBar style={navBarStyles}>
-              <Dropdown>
-                <Dropdown.Toggle>Portfolios</Dropdown.Toggle>
-                <Dropdown.Menu>
-                  {portfolioDropdownItems?.map((item) => (
-                    <Dropdown.Item key={item.name} item={item} />
-                  ))}
-                  <Dropdown.Item
-                    item={{
-                      name: "포트폴리오로 이동",
-                      onClick: () => navigate("/portfolios"),
-                    }}
-                  />
-                  <Dropdown.Item
-                    item={{
-                      name: "포트폴리오 추가",
-                      onClick: onPortfolioAddClick,
-                    }}
-                  />
-                </Dropdown.Menu>
-              </Dropdown>
+              <PortfoliosDropdown
+                portfolioDropdownItems={portfolioDropdownItems}
+                onPortfolioAddClick={onPortfolioAddClick}
+              />
               {navItems.map((item) => (
                 <NavBar.NavItem
                   key={item.name}

--- a/src/components/common/PortfoliosDropdown.tsx
+++ b/src/components/common/PortfoliosDropdown.tsx
@@ -1,0 +1,58 @@
+import { useDropdown } from "@components/hooks/useDropdown";
+import designSystem from "@styles/designSystem";
+import { useNavigate } from "react-router-dom";
+
+type Props = {
+  portfolioDropdownItems:
+    | {
+        name: string;
+        onClick: () => void;
+      }[]
+    | undefined;
+  onPortfolioAddClick: () => void;
+};
+
+export function PortfoliosDropdown({
+  portfolioDropdownItems,
+  onPortfolioAddClick,
+}: Props) {
+  const navigate = useNavigate();
+  const { DropdownMenu, DropdownItem, onOpen } = useDropdown();
+
+  return (
+    <>
+      <button style={buttonStyle} onClick={onOpen}>
+        Portfolios
+      </button>
+      <DropdownMenu>
+        {portfolioDropdownItems?.map((item) => (
+          <DropdownItem key={item.name} item={item} />
+        ))}
+
+        <DropdownItem
+          item={{
+            name: "포트폴리오로 이동",
+            onClick: () => navigate("/portfolios"),
+          }}
+        />
+        <DropdownItem
+          item={{
+            name: "포트폴리오 추가",
+            onClick: onPortfolioAddClick,
+          }}
+        />
+      </DropdownMenu>
+    </>
+  );
+}
+
+const buttonStyle = {
+  width: "80px",
+  height: "40px",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  font: designSystem.font.title4,
+  letterSpacing: "-0.02em",
+  cursor: "pointer",
+};

--- a/src/components/hooks/useDropdown.tsx
+++ b/src/components/hooks/useDropdown.tsx
@@ -1,0 +1,59 @@
+import { Menu, MenuItem } from "@mui/material";
+import { ReactNode, useState } from "react";
+import { CSSProperties } from "styled-components";
+
+type DropdownMenuProps = {
+  children: ReactNode;
+  style?: CSSProperties;
+};
+
+type DropdownItemProps = {
+  item: {
+    name: string;
+    onClick: () => void;
+  };
+  style?: CSSProperties;
+};
+
+export function useDropdown() {
+  const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null);
+
+  const open = Boolean(anchorElement);
+
+  const onOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorElement(event.currentTarget);
+  };
+
+  const onClose = () => {
+    setAnchorElement(null);
+  };
+
+  function DropdownMenu({ children, style }: DropdownMenuProps) {
+    return (
+      <Menu
+        style={style}
+        anchorEl={anchorElement}
+        open={open}
+        onClose={onClose}>
+        {children}
+      </Menu>
+    );
+  }
+
+  function DropdownItem({ item, style }: DropdownItemProps) {
+    const { name, onClick } = item;
+
+    const onClickHandler = () => {
+      onClick();
+      onClose();
+    };
+
+    return (
+      <MenuItem style={style} onClick={onClickHandler}>
+        {name}
+      </MenuItem>
+    );
+  }
+
+  return { onOpen, onClose, DropdownMenu, DropdownItem };
+}


### PR DESCRIPTION
## 구현한 것
- MUI를 활용해서 Dropdown을 구현 할 수 있도록 `useDropdown` custom hook 구현 했습니다.
  - 저는 기존 박하가 구현했던 head less 방식보다 custom hook으로 구현하는게 편하다 보니 많이 변경된 것 같네요.
- dropdown의 시작 포인트가 될 button의 경우 dropdown의 `기획`, `디자인`에 따라서 모두 다를 것 이라 생각 했습니다.
  - 그래서 따로 custom hook에서 관리하는게 아닌 특정 `기획`, `디자인`에 맞는 dropdown을 구현 할 때 그 곳에 맞는 button을 추가하는 방식을 생각 했습니다.
  - ex) `PortfoliosDropdown.tsx`
- `DropdownMenu`, `DropdownItem`은 style props를 받아 사용처에 맞게 커스터마이징 가능하도록 구현 했습니다.

## 기타
- 공용 컴포넌트 `Button`에 있는 `onClick`이 () => void로 선언 되어 있어 callback에 event를 넘겨 받는 경우 사용하지 못하고 있습니다.
- 위 문제에 맞게 `Button` 컴포넌트 수정 부탁드립니다.
- 혹시 몰라서 기존 `Dropdown.tsx` 컴포넌트는 삭제하지 않은 상태 입니다.
  - pr 리뷰가 끝나고 confirm 받은 뒤 삭제하겠습니다.
