### PR TITLE
공용 컴포넌트 customTooltip 구현

### DIFF
--- a/src/components/common/AutoTooltipText.tsx
+++ b/src/components/common/AutoTooltipText.tsx
@@ -1,0 +1,44 @@
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { CustomTooltip } from "./CustomTooltip";
+
+type Props = {
+  children: ReactNode;
+  maxWidth: string;
+};
+
+export const AutoTooltipText = ({ children, maxWidth }: Props) => {
+  const [isTextOverflow, setIsTextOverflow] = useState(false);
+  const textRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const compareSize = () => {
+      if (textRef.current) {
+        const isOverflow =
+          textRef.current.scrollWidth > textRef.current.clientWidth;
+        setIsTextOverflow(isOverflow);
+      }
+    };
+
+    window.addEventListener("resize", compareSize);
+    compareSize();
+
+    return () => {
+      window.removeEventListener("resize", compareSize);
+    };
+  }, [children]);
+
+  return (
+    <CustomTooltip smallPadding title={isTextOverflow ? children : ""}>
+      <div
+        ref={textRef}
+        style={{
+          maxWidth: maxWidth,
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}>
+        {children}
+      </div>
+    </CustomTooltip>
+  );
+};

--- a/src/components/common/CustomTooltip.tsx
+++ b/src/components/common/CustomTooltip.tsx
@@ -23,7 +23,7 @@ const CustomStyledTooltip = styled(
           {
             name: "offset",
             options: {
-              offset: [0, -10],
+              offset: props.arrow ? [-7, -5] : [-7, -10],
             },
           },
         ],
@@ -43,6 +43,7 @@ const CustomStyledTooltip = styled(
 
   & .${tooltipClasses.arrow} {
     color: ${designSystem.color.neutral.white};
+    transform: translate(5px, 0px) !important;
     &::before {
       border: 1px solid ${designSystem.color.primary.blue100};
     }

--- a/src/components/common/CustomTooltip.tsx
+++ b/src/components/common/CustomTooltip.tsx
@@ -1,0 +1,50 @@
+import { Tooltip, TooltipProps, tooltipClasses } from "@mui/material";
+import designSystem from "@styles/designSystem";
+import { ReactElement } from "react";
+import styled from "styled-components";
+
+type Props = TooltipProps & { children: ReactElement; smallPadding?: boolean };
+
+export function CustomTooltip({ children, smallPadding, ...props }: Props) {
+  return (
+    <CustomStyledTooltip $smallPadding={smallPadding} {...props}>
+      {children}
+    </CustomStyledTooltip>
+  );
+}
+
+const CustomStyledTooltip = styled(
+  ({ className, ...props }: TooltipProps & { $smallPadding?: boolean }) => (
+    <Tooltip
+      {...props}
+      PopperProps={{
+        className,
+        modifiers: [
+          {
+            name: "offset",
+            options: {
+              offset: [0, -10],
+            },
+          },
+        ],
+      }}
+    />
+  )
+)`
+  & .${tooltipClasses.tooltip} {
+    padding: ${({ $smallPadding }) => ($smallPadding ? "4px" : "8px")};
+    border-radius: 4px;
+    border: 1px solid ${designSystem.color.primary.blue100};
+    background: ${designSystem.color.neutral.white};
+    box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
+    color: ${designSystem.color.neutral.gray800};
+    font: ${designSystem.font.body4};
+  }
+
+  & .${tooltipClasses.arrow} {
+    color: ${designSystem.color.neutral.white};
+    &::before {
+      border: 1px solid ${designSystem.color.primary.blue100};
+    }
+  }
+`;

--- a/src/components/common/CustomTooltip.tsx
+++ b/src/components/common/CustomTooltip.tsx
@@ -23,7 +23,7 @@ const CustomStyledTooltip = styled(
           {
             name: "offset",
             options: {
-              offset: props.arrow ? [-7, -5] : [-7, -10],
+              offset: props.arrow ? [0, -5] : [0, -10],
             },
           },
         ],
@@ -32,6 +32,7 @@ const CustomStyledTooltip = styled(
   )
 )`
   & .${tooltipClasses.tooltip} {
+    max-width: 400px;
     padding: ${({ $smallPadding }) => ($smallPadding ? "4px" : "8px")};
     border-radius: 4px;
     border: 1px solid ${designSystem.color.primary.blue100};
@@ -43,7 +44,6 @@ const CustomStyledTooltip = styled(
 
   & .${tooltipClasses.arrow} {
     color: ${designSystem.color.neutral.white};
-    transform: translate(5px, 0px) !important;
     &::before {
       border: 1px solid ${designSystem.color.primary.blue100};
     }

--- a/src/components/common/EllipsisTextTooltip.tsx
+++ b/src/components/common/EllipsisTextTooltip.tsx
@@ -6,7 +6,7 @@ type Props = {
   maxWidth: string;
 };
 
-export const AutoTooltipText = ({ children, maxWidth }: Props) => {
+export const EllipsisTextTooltip = ({ children, maxWidth }: Props) => {
   const [isTextOverflow, setIsTextOverflow] = useState(false);
   const textRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
## 구현한 것
- MUI를 활용해서 `customTooltip.tsx` 구현
- 텍스트가 길어서 줄임 처리 되었을 때 사용 할  `AutoTooltipText.tsx` 구현
  - `AutoTooltipText`는 텍스트를 감싸서 사용합니다.
  - `AutoTooltipText`에 지정된 길이 보다 텍스트가 길 경우에만 hover시 tooltip이 표시됩니다.
  - 화면의 크기, 텍스트의 크기를 항시 확인하고 tooltip을 걸어 줄 수 없다 생각해 필요하다 판단되는 text를 wrapping하여 사용하면 될 것 같습니다.
### 사용 예시
```tsx
<AutoTooltipText maxWidth="200px">
  여기에 긴 텍스트를 넣으세요~~~~~~~~~~
</AutoTooltipText>
<AutoTooltipText maxWidth="200px">적당한 텍스트 입니다</AutoTooltipText>

<CustomTooltip placement="bottom-start" title={"tooltip~~~"} arrow>
  <div>커스텀 툴팁</div>
</CustomTooltip>

// title은 컴포넌트도 가능합니다.
<CustomTooltip placement="bottom-start" title={<div>tooltip</div>} arrow>
  <div>?</div>
</CustomTooltip>
```


## 기타
- `AutoTooltipText`의 경우 최대 width를 모카에게 질문한 상태라서 수정될 예정입니다.
  - 최대 400px로 정의
- ~`CustomTooltip`의 경우 prop `placement="bottom-start"`가 평균적인 디자인에 따라서 디폴트가 될 수 있을 것 수정될 수 있습니다.~
  - 툴팁이 특정 위치에 있는 경우 올바르지 못한 위치에 화살표가 표기 되는 현상으로  `placement="bottom-start"`와 화살표의 위치는 보통 가운데가 되도록 수정 했습니다.
- 위 내용과 리뷰 적용하고 머지하면 될 것 같습니다.
