### PR TITLE
대시보드 suspend&error boundary 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "lightweight-charts-react-wrapper": "^2.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.11",
         "react-movable": "^3.0.4",
         "react-router-dom": "^6.16.0",
         "react-toastify": "^9.1.3",
@@ -8972,6 +8973,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
+      "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lightweight-charts-react-wrapper": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-movable": "^3.0.4",
     "react-router-dom": "^6.16.0",
     "react-toastify": "^9.1.3",

--- a/src/api/dashboard/queries/useDashboardLineChartQuery.tsx
+++ b/src/api/dashboard/queries/useDashboardLineChartQuery.tsx
@@ -1,14 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { getTotalValuationLineChart } from "..";
 import { dashboardKeys } from "./queryKeys";
 
 export default function useDashboardTotalValuationTrendQuery() {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: dashboardKeys.lineChart().queryKey,
     queryFn: getTotalValuationLineChart,
     select: (res) => res.data,
     meta: {
       errorMessage: "라인 차트 정보를 불러오는데 실패했습니다",
     },
+    retry: 0,
   });
 }

--- a/src/api/dashboard/queries/useDashboardOverviewQuery.tsx
+++ b/src/api/dashboard/queries/useDashboardOverviewQuery.tsx
@@ -1,14 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { getDashboardOverview } from "..";
 import { dashboardKeys } from "./queryKeys";
 
 export default function useDashboardOverviewQuery() {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: dashboardKeys.overview().queryKey,
     queryFn: getDashboardOverview,
     select: (res) => res.data,
     meta: {
       errorMessage: "오버뷰 정보를 불러오는데 실패했습니다",
     },
+    retry: 0,
   });
 }

--- a/src/api/dashboard/queries/useDashboardPieChartQuery.tsx
+++ b/src/api/dashboard/queries/useDashboardPieChartQuery.tsx
@@ -1,15 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
-
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { getPortfoliosWeightPieChart } from "..";
 import { dashboardKeys } from "./queryKeys";
 
 export default function useDashboardPieChartQuery() {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: dashboardKeys.pieChart().queryKey,
     queryFn: getPortfoliosWeightPieChart,
     select: (res) => res.data,
     meta: {
       errorMessage: "파이 차트 정보를 불러오는데 실패했습니다",
     },
+    retry: 0,
   });
 }

--- a/src/components/Dashboard/errorFallback/ChartErrorFallback.tsx
+++ b/src/components/Dashboard/errorFallback/ChartErrorFallback.tsx
@@ -1,0 +1,31 @@
+import { ErrorFallbackContent } from "@components/common/ErrorFallbackContent";
+import { FallbackProps } from "react-error-boundary";
+import styled from "styled-components";
+
+export function ChartErrorFallback({
+  error,
+  resetErrorBoundary,
+}: FallbackProps) {
+  return (
+    <StyledDashboardPieChart>
+      <ErrorFallbackContent
+        error={error}
+        resetErrorBoundary={resetErrorBoundary}
+      />
+    </StyledDashboardPieChart>
+  );
+}
+
+const StyledDashboardPieChart = styled.div`
+  width: 50%;
+  height: 480px;
+  padding: 32px;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  background-color: #ffffff;
+  border-radius: 10px;
+  gap: 24px;
+`;

--- a/src/components/Dashboard/errorFallback/OverviewErrorFallback.tsx
+++ b/src/components/Dashboard/errorFallback/OverviewErrorFallback.tsx
@@ -1,0 +1,31 @@
+import { ErrorFallbackContent } from "@components/common/ErrorFallbackContent";
+import { FallbackProps } from "react-error-boundary";
+import styled from "styled-components";
+
+export function OverviewErrorFallback({
+  error,
+  resetErrorBoundary,
+}: FallbackProps) {
+  return (
+    <StyledDashboardOverview>
+      <ErrorFallbackContent
+        error={error}
+        resetErrorBoundary={resetErrorBoundary}
+      />
+    </StyledDashboardOverview>
+  );
+}
+
+const StyledDashboardOverview = styled.div`
+  width: 100%;
+  height: 316px;
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  position: relative;
+  background-color: ${({ theme: { color } }) => color.neutral.gray800};
+  color: ${({ theme: { color } }) => color.neutral.white};
+`;

--- a/src/components/Dashboard/skeletons/DashboardLineChartSkeleton.tsx
+++ b/src/components/Dashboard/skeletons/DashboardLineChartSkeleton.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from "@mui/material";
+import styled from "styled-components";
+
+export function DashboardLineChartSkeleton() {
+  return (
+    <StyledDashboardLineChartSkeleton>
+      <Skeleton variant="rounded" width={"100%"} height={29} />
+      <StyledDiv>
+        <Skeleton variant="rounded" width={264} height={32} />
+      </StyledDiv>
+      <Skeleton variant="rounded" width={644} height={327} />
+    </StyledDashboardLineChartSkeleton>
+  );
+}
+
+const StyledDashboardLineChartSkeleton = styled.div`
+  width: 50%;
+  height: 480px;
+  padding: 32px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  border-radius: 10px;
+  gap: 24px;
+`;
+
+const StyledDiv = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: right;
+`;

--- a/src/components/Dashboard/skeletons/DashboardOverviewSkeleton.tsx
+++ b/src/components/Dashboard/skeletons/DashboardOverviewSkeleton.tsx
@@ -1,0 +1,107 @@
+import { Skeleton } from "@mui/material";
+import designSystem from "@styles/designSystem";
+import styled from "styled-components";
+
+export function DashboardOverviewSkeleton() {
+  return (
+    <StyledDashboardOverviewSkeleton>
+      <InnerWrapper>
+        <StyledSkeleton variant="rounded" width={"100%"} height={39} />
+        <ContentContainer>
+          <TotalMainContentWrapper>
+            <StyledSkeleton variant="rounded" width={76} height={19} />
+            <StyledSkeleton variant="rounded" width={"100%"} height={58} />
+          </TotalMainContentWrapper>
+          <SubContentContainer>
+            <TotalSubContentWrapper>
+              <StyledSkeleton variant="rounded" width={76} height={19} />
+              <StyledSkeleton variant="rounded" width={"100%"} height={34} />
+            </TotalSubContentWrapper>
+            <TotalSubContentWrapper>
+              <StyledSkeleton variant="rounded" width={76} height={19} />
+              <StyledSkeleton variant="rounded" width={"100%"} height={34} />
+              <StyledSkeleton variant="rounded" width={61} height={24} />
+            </TotalSubContentWrapper>
+            <TotalSubContentWrapper>
+              <StyledSkeleton variant="rounded" width={76} height={19} />
+              <StyledSkeleton variant="rounded" width={"100%"} height={34} />
+              <StyledSkeleton variant="rounded" width={61} height={24} />
+            </TotalSubContentWrapper>
+          </SubContentContainer>
+        </ContentContainer>
+      </InnerWrapper>
+    </StyledDashboardOverviewSkeleton>
+  );
+}
+
+const StyledDashboardOverviewSkeleton = styled.div`
+  width: 100%;
+  height: 316px;
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  position: relative;
+  background-color: ${({ theme: { color } }) => color.neutral.gray800};
+  color: ${({ theme: { color } }) => color.neutral.white};
+`;
+
+const InnerWrapper = styled.div`
+  width: 100%;
+  max-width: 1440px;
+  height: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+`;
+
+const ContentContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+`;
+
+const TotalMainContentWrapper = styled.div`
+  width: 586px;
+  height: 157px;
+  padding-top: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 8px;
+  color: ${({ theme: { color } }) => color.neutral.white};
+`;
+
+const SubContentContainer = styled.div`
+  display: flex;
+  width: 830px;
+  height: 157px;
+  padding: 24px 0;
+  background-color: ${({ theme: { color } }) => color.neutral.white04};
+  border-radius: 8px;
+  border: 1px solid ${({ theme: { color } }) => color.neutral.gray700};
+
+  & > * {
+    border-right: 1px solid ${({ theme: { color } }) => color.neutral.gray700};
+  }
+
+  & > *:last-child {
+    border-right: none;
+  }
+`;
+
+const TotalSubContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 8px;
+  padding: 0 24px;
+`;
+
+const StyledSkeleton = styled(Skeleton)`
+  background-color: ${designSystem.color.neutral.gray700};
+`;

--- a/src/components/Dashboard/skeletons/DashboardPieChartSkeleton.tsx
+++ b/src/components/Dashboard/skeletons/DashboardPieChartSkeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from "@mui/material";
+import styled from "styled-components";
+import { PieChartLegendSkeleton } from "./PieChartLegendSkeleton";
+import { PieChartSkeleton } from "./PieChartSkeleton";
+
+export default function DashboardPieChartSkeleton() {
+  return (
+    <StyledDashboardPieChartSkeleton>
+      <Skeleton variant="rounded" width={"100%"} height={29} />
+      <Wrapper>
+        <PieChartSkeleton size={288} innerSize={160} />
+        <PieChartLegendSkeleton />
+      </Wrapper>
+    </StyledDashboardPieChartSkeleton>
+  );
+}
+
+const StyledDashboardPieChartSkeleton = styled.div`
+  width: 50%;
+  height: 480px;
+  padding: 32px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  border-radius: 10px;
+  gap: 24px;
+`;
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+`;

--- a/src/components/Dashboard/skeletons/PieChartLegendSkeleton.tsx
+++ b/src/components/Dashboard/skeletons/PieChartLegendSkeleton.tsx
@@ -7,7 +7,7 @@ export function PieChartLegendSkeleton() {
     return <LegendSkeleton />;
   });
 
-  const other = Array.from({ length: 2 }, () => {
+  const otherLegend = Array.from({ length: 2 }, () => {
     return <LegendSkeleton />;
   });
 
@@ -15,7 +15,7 @@ export function PieChartLegendSkeleton() {
     <StyledPieChartLegendSkeleton>
       {legend}
       <Skeleton width={"100%"} height={3} />
-      {other}
+      {otherLegend}
     </StyledPieChartLegendSkeleton>
   );
 }

--- a/src/components/Dashboard/skeletons/PieChartLegendSkeleton.tsx
+++ b/src/components/Dashboard/skeletons/PieChartLegendSkeleton.tsx
@@ -1,0 +1,50 @@
+import { Skeleton } from "@mui/material";
+import designSystem from "@styles/designSystem";
+import styled from "styled-components";
+
+export function PieChartLegendSkeleton() {
+  const legend = Array.from({ length: 10 }, () => {
+    return <LegendSkeleton />;
+  });
+
+  const other = Array.from({ length: 2 }, () => {
+    return <LegendSkeleton />;
+  });
+
+  return (
+    <StyledPieChartLegendSkeleton>
+      {legend}
+      <Skeleton width={"100%"} height={3} />
+      {other}
+    </StyledPieChartLegendSkeleton>
+  );
+}
+
+function LegendSkeleton() {
+  return (
+    <Wrapper>
+      <Skeleton variant="rounded" width={206} height={17} />
+      <Skeleton variant="rounded" width={30} height={15} />
+    </Wrapper>
+  );
+}
+
+const StyledPieChartLegendSkeleton = styled.div`
+  display: flex;
+  width: 300px;
+  height: 363px;
+  padding: 24px;
+  flex-direction: column;
+  align-items: flex-start;
+  border-radius: 8px;
+  gap: 8px;
+  flex-shrink: 0;
+  border: 1px solid ${designSystem.color.neutral.gray200};
+  background: ${designSystem.color.neutral.white};
+`;
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 16px;
+`;

--- a/src/components/Dashboard/skeletons/PieChartSkeleton.tsx
+++ b/src/components/Dashboard/skeletons/PieChartSkeleton.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@mui/material";
+import styled from "styled-components";
+
+type Props = {
+  size: number;
+  innerSize: number;
+};
+
+export function PieChartSkeleton({ size, innerSize }: Props) {
+  return (
+    <StyledPieChartSkeleton>
+      <Skeleton variant="circular" width={size} height={size} />
+      <InnerCircle $width={innerSize} $height={innerSize} />
+    </StyledPieChartSkeleton>
+  );
+}
+
+const StyledPieChartSkeleton = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`;
+
+const InnerCircle = styled.div<{
+  $width: number;
+  $height: number;
+}>`
+  width: ${({ $width }) => $width}px;
+  height: ${({ $height }) => $height}px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background-color: #ffffff;
+`;

--- a/src/components/common/AsyncBoundary.tsx
+++ b/src/components/common/AsyncBoundary.tsx
@@ -1,0 +1,20 @@
+import { ComponentType, ReactNode, Suspense } from "react";
+import { ErrorBoundary, FallbackProps } from "react-error-boundary";
+
+type Props = {
+  children: ReactNode;
+  errorFallback: ComponentType<FallbackProps>;
+  suspenseFallback: ReactNode;
+};
+
+export function AsyncBoundary({
+  children,
+  errorFallback,
+  suspenseFallback,
+}: Props) {
+  return (
+    <ErrorBoundary FallbackComponent={errorFallback}>
+      <Suspense fallback={suspenseFallback}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/src/components/common/ErrorFallbackContent.tsx
+++ b/src/components/common/ErrorFallbackContent.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@mui/material";
+import { FallbackProps } from "react-error-boundary";
+import styled from "styled-components";
+
+export function ErrorFallbackContent({
+  error,
+  resetErrorBoundary,
+}: FallbackProps) {
+  return (
+    <>
+      <Title>서버로부터 데이터를 불러오지 못했습니다.</Title>
+      <Content>새로고침을 하거나 잠시 후 다시 시도해 주세요.</Content>
+      <div>{error.message}</div>
+      <Button variant="contained" onClick={resetErrorBoundary}>
+        새로고침
+      </Button>
+    </>
+  );
+}
+
+const Title = styled.div`
+  font-size: 24px;
+  line-height: 29px;
+  font-weight: bold;
+`;
+
+const Content = styled.div`
+  font-size: 16px;
+  line-height: 29px;
+`;

--- a/src/components/common/ErrorFallbackContent.tsx
+++ b/src/components/common/ErrorFallbackContent.tsx
@@ -2,15 +2,11 @@ import { Button } from "@mui/material";
 import { FallbackProps } from "react-error-boundary";
 import styled from "styled-components";
 
-export function ErrorFallbackContent({
-  error,
-  resetErrorBoundary,
-}: FallbackProps) {
+export function ErrorFallbackContent({ resetErrorBoundary }: FallbackProps) {
   return (
     <>
       <Title>서버로부터 데이터를 불러오지 못했습니다.</Title>
       <Content>새로고침을 하거나 잠시 후 다시 시도해 주세요.</Content>
-      <div>{error.message}</div>
       <Button variant="contained" onClick={resetErrorBoundary}>
         새로고침
       </Button>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,18 +1,35 @@
 import DashboardOverview from "@components/Dashboard/DashboardOverview";
 import DashboardPortfolioWeight from "@components/Dashboard/DashboardPortfolioWeight";
 import DashboardTotalValuationTrend from "@components/Dashboard/DashboardTotalValuationTrend";
+import { ChartErrorFallback } from "@components/Dashboard/errorFallback/ChartErrorFallback";
+import { OverviewErrorFallback } from "@components/Dashboard/errorFallback/OverviewErrorFallback";
+import { DashboardLineChartSkeleton } from "@components/Dashboard/skeletons/DashboardLineChartSkeleton";
+import { DashboardOverviewSkeleton } from "@components/Dashboard/skeletons/DashboardOverviewSkeleton";
+import DashboardPieChartSkeleton from "@components/Dashboard/skeletons/DashboardPieChartSkeleton";
+import { AsyncBoundary } from "@components/common/AsyncBoundary";
 import styled from "styled-components";
 import BasePage from "./BasePage";
 
 export default function DashboardPage() {
   return (
     <BasePage>
-      <DashboardOverview />
-
+      <AsyncBoundary
+        errorFallback={OverviewErrorFallback}
+        suspenseFallback={<DashboardOverviewSkeleton />}>
+        <DashboardOverview />
+      </AsyncBoundary>
       <ChartsWrapper>
         <ChartsContainer>
-          <DashboardPortfolioWeight />
-          <DashboardTotalValuationTrend />
+          <AsyncBoundary
+            errorFallback={ChartErrorFallback}
+            suspenseFallback={<DashboardPieChartSkeleton />}>
+            <DashboardPortfolioWeight />
+          </AsyncBoundary>
+          <AsyncBoundary
+            errorFallback={ChartErrorFallback}
+            suspenseFallback={<DashboardLineChartSkeleton />}>
+            <DashboardTotalValuationTrend />
+          </AsyncBoundary>
         </ChartsContainer>
       </ChartsWrapper>
     </BasePage>


### PR DESCRIPTION
## 구현한 것
- errorBoundary 사용을 간단하게 할 수 있게 도와주는 `react-error-boundary` 라이브러리 추가
- `suspend&error boundary`를 한번에 적용 가능한 `AsyncBoundary` 구현
- errorBoundary에서 사용할 fallback의 공용 컴포넌트 `ErrorFallbackContent` 구현
- 대시보드 각각 fallback `ChartErrorFallback`, `OverviewErrorFallback` 구현
- 대시보드의 각각 스켈레톤 `DashboardLineChartSkeleton`, `DashboardOverviewSkeleton`, `DashboardPieChartSkeleton` 구현

## 기타
- fallback, skeleton, 원본 component 모두 공통적으로 사용하는 style이 너무 많이 중복되고 있습니다.
- 이 부분 어떻게 해결하면 좋을까요?
