### PR TITLE
portfolio add dialog 리팩터링

### DIFF
--- a/src/components/Portfolio/PortfolioAddDialog.tsx
+++ b/src/components/Portfolio/PortfolioAddDialog.tsx
@@ -239,7 +239,7 @@ export default function PortfolioAddDialog({
                       alt={option}
                     />
                     <SecuritiesFirmTitle>
-                      {option === "FineAnts" ? "선택안함" : option}
+                      {option === "FineAnts" ? "FineAnts (선택안함)" : option}
                     </SecuritiesFirmTitle>
                   </SelectOption>
                 ))}
@@ -286,7 +286,9 @@ export default function PortfolioAddDialog({
             <StyledSpan>최대 손실율</StyledSpan>
             <InputWrapper>
               <StyledInput>
+                {maximumLossRate && <span>-</span>}
                 <Input
+                  style={{ paddingLeft: "3px" }}
                   disabled={isBudgetEmpty}
                   value={maximumLossRate}
                   onChange={(e) =>

--- a/src/components/Portfolio/PortfolioAddDialog.tsx
+++ b/src/components/Portfolio/PortfolioAddDialog.tsx
@@ -7,7 +7,7 @@ import { Icon } from "@components/common/Icon";
 import { Select, SelectOption } from "@components/common/Select";
 import { SECURITIES_FIRM } from "@constants/securitiesFirm";
 import { useText } from "@fineants/demolition";
-import { FormControl } from "@mui/material";
+import { FormControl, IconButton } from "@mui/material";
 import securitiesFirmLogos, {
   SecuritiesFirm,
 } from "@styles/securitiesFirmLogos";
@@ -147,15 +147,22 @@ export default function PortfolioAddDialog({
   useEffect(() => {
     if (isBudgetEmpty) {
       clearInputs();
-    } else {
+    }
+
+    if (targetGain || targetReturnRate) {
       onTargetGainHandler(targetGain);
+    }
+
+    if (maximumLoss || maximumLossRate) {
       onMaximumLossHandler(maximumLoss);
     }
   }, [
     budget,
-    targetGain,
     isBudgetEmpty,
+    targetGain,
+    targetReturnRate,
     maximumLoss,
+    maximumLossRate,
     clearInputs,
     onMaximumLossHandler,
     onTargetGainHandler,
@@ -172,14 +179,7 @@ export default function PortfolioAddDialog({
   }, [isEditSuccess, isEditError, onClose]);
 
   const isFormValid = () => {
-    if (
-      !name ||
-      !budget ||
-      !targetGain ||
-      !targetReturnRate ||
-      !maximumLoss ||
-      !maximumLossRate
-    ) {
+    if (!name) {
       return false;
     }
 
@@ -206,9 +206,9 @@ export default function PortfolioAddDialog({
       <Wrapper>
         <HeaderWrapper>
           <Header>포트폴리오 {isEditMode ? `수정` : `추가`}</Header>
-          <Button size="h32" variant="tertiary" onClick={onClose}>
+          <IconButton onClick={onClose}>
             <Icon size={24} icon="close" color={"gray600"} />
-          </Button>
+          </IconButton>
         </HeaderWrapper>
         <Body>
           <Row>

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -94,9 +94,8 @@ const StyledIcon = styled.div<{
 }>`
   width: ${({ $size }) => `${$size}px`};
   height: ${({ $size }) => `${$size}px`};
-
   background-color: ${({ $color }) => $color};
-
+  mask-size: ${({ $size }) => `${$size}px`};
   mask-image: url(${({ $iconUrl }) => $iconUrl});
   mask-repeat: no-repeat;
   mask-position: center;

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -95,7 +95,7 @@ const StyledIcon = styled.div<{
   width: ${({ $size }) => `${$size}px`};
   height: ${({ $size }) => `${$size}px`};
   background-color: ${({ $color }) => $color};
-  mask-size: ${({ $size }) => `${$size}px`};
+  mask-size: contain;
   mask-image: url(${({ $iconUrl }) => $iconUrl});
   mask-repeat: no-repeat;
   mask-position: center;

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -12,6 +12,7 @@ export type Size = "h24" | "h32" | "h40";
 
 type Props = {
   size: Size;
+  menuMinHeight?: number;
   selectedValue: string;
   changeSelectedValue: (value: string) => void;
   children: ReactNode;
@@ -22,6 +23,7 @@ type Props = {
  */
 export default function Select({
   size,
+  menuMinHeight,
   selectedValue,
   changeSelectedValue,
   children,
@@ -48,7 +50,7 @@ export default function Select({
       IconComponent={() => (
         <StyledIconComponent src={isOpen ? chevronUp : chevronDown} />
       )}
-      MenuProps={{ sx: MenuSX(size) }}>
+      MenuProps={{ sx: MenuSX(size, menuMinHeight) }}>
       {children}
     </MuiSelect>
   );
@@ -87,8 +89,9 @@ const StyledIconComponent = styled.img`
   pointer-events: none;
 `;
 
-const MenuSX = (size: Size) => ({
+const MenuSX = (size: Size, menuMinHeight?: number) => ({
   "& .MuiPaper-root": {
+    "height": menuMinHeight ? `${menuMinHeight}px` : "160px",
     "minWidth": `${size === "h24" ? 56 : 80}px`,
     "marginTop": "2px",
     "padding": "4px",

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -98,7 +98,6 @@ export default createGlobalStyle`
 
     &::-webkit-scrollbar-thumb {
       width: 4px;
-      height: 156px;
       background-color: ${designSystem.color.neutral.gray200};
       border-radius: 4px;
       border: 2px solid ${designSystem.color.neutral.white}; 


### PR DESCRIPTION
## 구현한 것
- Icon 컴포넌트 size 적용 안되는 문제 해결
- portfolio add dialog에 닫기 icon 버튼에 border 제거
- portfolio add dialog에 예산 여부 제거
- portfolio add dialog에 예산과 목표 수익률, 최대 손실률이 묶여 있는 상태 수정
- portfolio add dialog에 최대 손실률 앞에 - 기호 추가
- 스크롤 글로벌 스타일 높이 지정된 부분 제거
