### PR TITLE
알림 관련 리팩터링

### DIFF
--- a/src/api/notifications/queries/useMemberNotificationsSettingMutation.ts
+++ b/src/api/notifications/queries/useMemberNotificationsSettingMutation.ts
@@ -29,5 +29,9 @@ export function useMemberNotificationsSettingMutation(memberId: number) {
         navigate(Routes.SIGNIN);
       }
     },
+    meta: {
+      toastSuccessMessage: "알림 설정을 변경했습니다",
+      toastErrorMessage: "알림 설정에 실패했습니다",
+    },
   });
 }

--- a/src/api/notifications/types.ts
+++ b/src/api/notifications/types.ts
@@ -1,3 +1,5 @@
+import { SecuritiesFirm } from "@styles/securitiesFirmLogos";
+
 export type NotificationType = "stock" | "portfolio";
 
 export type MemberNotification = {
@@ -36,6 +38,7 @@ export type StockTargetPrice = {
 
 export type PortfolioNotification = {
   portfolioId: number;
+  securitiesFirm: SecuritiesFirm;
   name: string;
   targetGainNotify: boolean;
   maxLossNotify: boolean;

--- a/src/components/Notification/FeedbackCallout.tsx
+++ b/src/components/Notification/FeedbackCallout.tsx
@@ -1,0 +1,69 @@
+import { NotificationSettingsDialog } from "@components/common/Header/Notification/NotificationSettingsDialog";
+import { Icon } from "@components/common/Icon";
+import { UserContext } from "@context/UserContext";
+import designSystem from "@styles/designSystem";
+import { useContext, useState } from "react";
+import styled from "styled-components";
+
+type Props = {
+  message: string;
+};
+
+export function FeedbackCallout({ message }: Props) {
+  const { user } = useContext(UserContext);
+  const [isOpenDialog, setIsOpenDialog] = useState(false);
+
+  const openDialog = () => {
+    setIsOpenDialog(true);
+  };
+
+  const closeDialog = () => {
+    setIsOpenDialog(false);
+  };
+
+  return (
+    <>
+      <StyledFeedbackCallout>
+        <Icon icon="caption" size={16} color="gray400" />
+        <TextWrapper>
+          {message} 알림을 받으려면
+          <TextButton onClick={openDialog}> 알림 설정</TextButton> 을
+          변경하세요.
+        </TextWrapper>
+      </StyledFeedbackCallout>
+
+      {isOpenDialog && (
+        <NotificationSettingsDialog
+          user={user!}
+          isOpen={isOpenDialog}
+          onClose={closeDialog}
+        />
+      )}
+    </>
+  );
+}
+
+const StyledFeedbackCallout = styled.div`
+  width: 100%;
+  height: 45px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid ${designSystem.color.neutral.gray100};
+  border-radius: 4px;
+  padding: 15px 12px;
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font: ${designSystem.font.body3.font};
+  color: ${designSystem.color.neutral.gray600};
+`;
+
+const TextButton = styled.pre`
+  font: ${designSystem.font.body3.font};
+  color: ${designSystem.color.primary.blue500};
+  cursor: pointer;
+`;

--- a/src/components/Notification/PortfolioNotificationList/PortfolioNotificationListTable.tsx
+++ b/src/components/Notification/PortfolioNotificationList/PortfolioNotificationListTable.tsx
@@ -1,20 +1,54 @@
 import usePortfolioNotificationsQuery from "@api/notifications/queries/usePortfolioNotificationSettingsQuery";
 import PlainTable from "@components/common/Table/PlainTable";
+import { UserContext } from "@context/UserContext";
+import { useContext } from "react";
+import styled from "styled-components";
 import EmptyNotificationListTable from "../EmptyNotificationListTable";
+import { FeedbackCallout } from "../FeedbackCallout";
 import PortfolioNotificationListTableBody from "./PortfolioNotificationListTableBody";
 import PortfolioNotificationListTableHead from "./PortfolioNotificationListTableHead";
 
 export default function PortfolioNotificationListTable() {
   const { data } = usePortfolioNotificationsQuery();
+  const { user } = useContext(UserContext);
+
+  const maxLossNotifyFeedbackText = !user?.notificationPreferences.maxLossNotify
+    ? "최대 손실률"
+    : "";
+  const targetGainNotifyFeedbackText = !user?.notificationPreferences
+    .targetGainNotify
+    ? "목표 수익률"
+    : "";
+
+  const combinedFeedbackText =
+    maxLossNotifyFeedbackText && targetGainNotifyFeedbackText
+      ? `${maxLossNotifyFeedbackText}과 ${targetGainNotifyFeedbackText}`
+      : maxLossNotifyFeedbackText || targetGainNotifyFeedbackText;
 
   return (
-    <PlainTable
-      tableTitle="활성 포트폴리오 알림 목록"
-      initialOrderBy="lastUpdated"
-      TableHead={PortfolioNotificationListTableHead}
-      TableBody={PortfolioNotificationListTableBody}
-      EmptyTable={EmptyNotificationListTable}
-      data={data}
-    />
+    <StyledPortfolioNotificationListTable>
+      {(!user?.notificationPreferences.maxLossNotify ||
+        !user?.notificationPreferences.targetGainNotify) && (
+        <FeedbackCallout
+          message={`${combinedFeedbackText} 알림이 현재 비활성 상태입니다.`}
+        />
+      )}
+
+      <PlainTable
+        tableTitle="활성 포트폴리오 알림 목록"
+        initialOrderBy="lastUpdated"
+        TableHead={PortfolioNotificationListTableHead}
+        TableBody={PortfolioNotificationListTableBody}
+        EmptyTable={EmptyNotificationListTable}
+        data={data}
+      />
+    </StyledPortfolioNotificationListTable>
   );
 }
+
+const StyledPortfolioNotificationListTable = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;

--- a/src/components/Notification/PortfolioNotificationList/PortfolioNotificationRow.tsx
+++ b/src/components/Notification/PortfolioNotificationList/PortfolioNotificationRow.tsx
@@ -9,6 +9,7 @@ import {
   debounce,
 } from "@mui/material";
 import designSystem from "@styles/designSystem";
+import securitiesFirmLogos from "@styles/securitiesFirmLogos";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
@@ -17,7 +18,8 @@ type Props = {
 };
 
 export default function PortfolioNotificationRow({ row }: Props) {
-  const { portfolioId, name, targetGainNotify, maxLossNotify } = row;
+  const { portfolioId, securitiesFirm, name, targetGainNotify, maxLossNotify } =
+    row;
 
   const { mutate } = usePortfolioNotificationSettingsMutation(portfolioId);
 
@@ -42,7 +44,13 @@ export default function PortfolioNotificationRow({ row }: Props) {
           <StyledLink
             style={{ font: designSystem.font.body3.font }}
             to={`/portfolio/${portfolioId}`}>
-            {name}
+            <img
+              src={securitiesFirmLogos[securitiesFirm]}
+              alt={securitiesFirm}
+              width="32px"
+              height="32px"
+            />
+            <span className="portfolioName">{name}</span>
           </StyledLink>
         </Typography>
       </StyledTableCell>
@@ -91,6 +99,9 @@ const StyledTableCell = styled(TableCell)`
 `;
 
 const StyledLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font: ${designSystem.font.body3.font};
   color: ${designSystem.color.neutral.gray800};
 

--- a/src/components/Notification/StockNotificationList/StockNotificationListTable.tsx
+++ b/src/components/Notification/StockNotificationList/StockNotificationListTable.tsx
@@ -1,20 +1,38 @@
 import useStockNotificationSettingsQuery from "@api/notifications/queries/useStockNotificationSettingsQuery";
 import CollapsibleTable from "@components/common/Table/CollapsibleTable";
+import { UserContext } from "@context/UserContext";
+import { useContext } from "react";
+import styled from "styled-components";
 import EmptyNotificationListTable from "../EmptyNotificationListTable";
+import { FeedbackCallout } from "../FeedbackCallout";
 import StockNotificationListTableBody from "./StockNotificationListTableBody";
 import StockNotificationListTableHead from "./StockNotificationListTableHead";
 
 export default function StockNotificationListTable() {
   const { data } = useStockNotificationSettingsQuery();
+  const { user } = useContext(UserContext);
 
   return (
-    <CollapsibleTable
-      tableTitle="활성 종목 알림 목록"
-      initialOrderBy="lastUpdated"
-      TableHead={StockNotificationListTableHead}
-      TableBody={StockNotificationListTableBody}
-      EmptyTable={EmptyNotificationListTable}
-      data={data}
-    />
+    <StyledStockNotificationListTable>
+      {!user?.notificationPreferences.targetPriceNotify && (
+        <FeedbackCallout message="종목 알림이 현재 비활성 상태입니다." />
+      )}
+
+      <CollapsibleTable
+        tableTitle="활성 종목 알림 목록"
+        initialOrderBy="lastUpdated"
+        TableHead={StockNotificationListTableHead}
+        TableBody={StockNotificationListTableBody}
+        EmptyTable={EmptyNotificationListTable}
+        data={data}
+      />
+    </StyledStockNotificationListTable>
   );
 }
+
+const StyledStockNotificationListTable = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;

--- a/src/components/common/Header/Notification/NotificationControl.tsx
+++ b/src/components/common/Header/Notification/NotificationControl.tsx
@@ -33,9 +33,14 @@ export function NotificationControl({ user }: { user: User }) {
   const handleClose = () => {
     if (!notifications) return;
 
-    const notificationIds = notifications.map((data) => data.notificationId);
+    const unreadNotificationIds = notifications
+      .filter((data) => !data.isRead)
+      .map((obj) => obj.notificationId);
 
-    mutate(notificationIds);
+    if (unreadNotificationIds.length > 0) {
+      mutate(unreadNotificationIds);
+    }
+
     setAnchorEl(null);
   };
 

--- a/src/components/common/Header/Notification/NotificationControl.tsx
+++ b/src/components/common/Header/Notification/NotificationControl.tsx
@@ -34,10 +34,12 @@ export function NotificationControl({ user }: { user: User }) {
     if (!notifications) return;
 
     const unreadNotificationIds = notifications.reduce(
-      (accumulator: number[], currentValue) => (
-        !currentValue.isRead && accumulator.push(currentValue.notificationId),
-        accumulator
-      ),
+      (accumulator: number[], currentValue) => {
+        if (!currentValue.isRead) {
+          accumulator.push(currentValue.notificationId);
+        }
+        return accumulator;
+      },
       []
     );
 

--- a/src/components/common/Header/Notification/NotificationControl.tsx
+++ b/src/components/common/Header/Notification/NotificationControl.tsx
@@ -33,9 +33,13 @@ export function NotificationControl({ user }: { user: User }) {
   const handleClose = () => {
     if (!notifications) return;
 
-    const unreadNotificationIds = notifications
-      .filter((data) => !data.isRead)
-      .map((obj) => obj.notificationId);
+    const unreadNotificationIds = notifications.reduce(
+      (accumulator: number[], currentValue) => (
+        !currentValue.isRead && accumulator.push(currentValue.notificationId),
+        accumulator
+      ),
+      []
+    );
 
     if (unreadNotificationIds.length > 0) {
       mutate(unreadNotificationIds);

--- a/src/components/common/Header/Notification/NotificationSettingsDialog.tsx
+++ b/src/components/common/Header/Notification/NotificationSettingsDialog.tsx
@@ -98,7 +98,6 @@ export function NotificationSettingsDialog({ user, isOpen, onClose }: Props) {
           );
           if (newFCMTokenId) {
             onSubscribePushNotification(newFCMTokenId);
-            toast.success("알림 설정을 변경했습니다");
           }
         } else if (isAllInactive && fcmTokenId) {
           // 알림 설정이 모두 false라면 FCM에서 unsubscribe하고 서버에서 토큰 제거

--- a/src/mocks/data/notifications/notificationSettingsData.ts
+++ b/src/mocks/data/notifications/notificationSettingsData.ts
@@ -54,6 +54,7 @@ export const stockNotifications = [
 export const portfolioNotifications = [
   {
     portfolioId: 1,
+    securitiesFirm: "KB증권",
     name: "포트폴리오 1",
     targetGainNotify: true,
     maxLossNotify: true,
@@ -61,6 +62,7 @@ export const portfolioNotifications = [
   },
   {
     portfolioId: 2,
+    securitiesFirm: "토스증권",
     name: "포트폴리오 2",
     targetGainNotify: true,
     maxLossNotify: false,

--- a/src/pages/ActiveNotificationsPage/subPages/PortfolioNotificationsSubPage.tsx
+++ b/src/pages/ActiveNotificationsPage/subPages/PortfolioNotificationsSubPage.tsx
@@ -24,7 +24,7 @@ export default function PortfolioNotificationsSubPage() {
 
 const StyledPortfolioNotificationsSubPage = styled.div`
   min-height: 300px;
-  margin-top: 40px;
+  margin-top: 24px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/ActiveNotificationsPage/subPages/StockNotificationsSubPage.tsx
+++ b/src/pages/ActiveNotificationsPage/subPages/StockNotificationsSubPage.tsx
@@ -24,7 +24,7 @@ export default function StockNotificationsSubPage() {
 
 const StyledStockNotificationsSubPage = styled.div`
   min-height: 300px;
-  margin-top: 40px;
+  margin-top: 24px;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## 구현한 것
#### 활성 알림 페이지
- 알림 비활성화 시 활성 알림 페이지에서 설명 문구 추가
- 포트폴리오 알림
	- 포트폴리오 이름 왼쪽에 증권사 이미지 추가
	
#### 알림

- 알림 설정 Dialog
	- 설정 변경 성공 및 실패시 토스트 추가
- 알림 패널에서 내용이 없을 시 PATCH 모두 읽음 API 호출 안 하도록 변경

#### BE에 요청해 놓은 내용
- 첫 회원가입 시 notificationPreferences 모두 false로 요청
- 활성 알림 페이지 포트폴리오 리스트 api 명세에 증권사 추가 요청
- 알림 활성화/비활성화 버튼을 누를 시 서버에 반영이 되면서 list의 순서가 오래전에 업데이트된 순서로 받아와서 UI shift 안 생기도록 정렬 기준 변경 요청
- 알림 활성화/비활성화 버튼을 누를 시 서버에 반영이 되면서 list의 순서가 최근 업데이트된 순서로 받아와서 UI shift 안 생기도록 정렬 기준 변경 요청