### PR TITLE
비로그인 상태에 따른 액션 방어 리팩터링

### DIFF
--- a/src/components/Stock/TargetPriceAlertDropdown/TargetPriceAlertDropdown.tsx
+++ b/src/components/Stock/TargetPriceAlertDropdown/TargetPriceAlertDropdown.tsx
@@ -2,8 +2,11 @@ import { AsyncBoundary } from "@components/common/AsyncBoundary";
 import Button from "@components/common/Buttons/Button";
 import { Icon } from "@components/common/Icon";
 import { useDropdown } from "@components/hooks/useDropdown";
+import { UserContext } from "@context/UserContext";
+import Routes from "@router/Routes";
 import designSystem from "@styles/designSystem";
-import { MouseEvent } from "react";
+import { MouseEvent, useContext } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import StockTargetPriceForm from "../StockTargetPriceForm";
 import TargetPricesList from "./TargetPricesList";
@@ -11,9 +14,18 @@ import TargetPricesListErrorFallback from "./errorFallback/TargetPricesListError
 import TargetPricesListSkeleton from "./skeleton/TargetPricesListSkeleton";
 
 export default function TargetPriceAlertDropdown() {
+  const navigate = useNavigate();
+
+  const { user } = useContext(UserContext);
+
   const { onOpen, DropdownMenu } = useDropdown();
 
   const onDropdownButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (!user) {
+      navigate(Routes.SIGNIN);
+      return;
+    }
+
     onOpen(e);
   };
 

--- a/src/components/Stock/WatchlistHasStock/WatchlistHasStockDropdown.tsx
+++ b/src/components/Stock/WatchlistHasStock/WatchlistHasStockDropdown.tsx
@@ -3,9 +3,12 @@ import { AsyncBoundary } from "@components/common/AsyncBoundary";
 import Button from "@components/common/Buttons/Button";
 import { Icon } from "@components/common/Icon";
 import { useDropdown } from "@components/hooks/useDropdown";
+import { UserContext } from "@context/UserContext";
 import { Button as MuiButton } from "@mui/material";
+import Routes from "@router/Routes";
 import designSystem from "@styles/designSystem";
-import { MouseEvent, useState } from "react";
+import { MouseEvent, useContext, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import WatchlistHasStockList from "./WatchlistHasStockList";
 import WatchlistHasStockListError from "./errorFallback/WatchlistHasStockListErrorFallback";
@@ -16,6 +19,10 @@ type Props = {
 };
 
 export function WatchlistHasStockDropdown({ tickerSymbol }: Props) {
+  const navigate = useNavigate();
+
+  const { user } = useContext(UserContext);
+
   const { onOpen, DropdownMenu } = useDropdown();
 
   const [isNewWatchlistDialogOpen, setIsNewWatchlistDialogOpen] =
@@ -30,6 +37,11 @@ export function WatchlistHasStockDropdown({ tickerSymbol }: Props) {
   };
 
   const onDropdownButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (!user) {
+      navigate(Routes.SIGNIN);
+      return;
+    }
+
     onOpen(e);
   };
 

--- a/src/components/common/Header/PortfoliosDropdown/PortfoliosDropdown.tsx
+++ b/src/components/common/Header/PortfoliosDropdown/PortfoliosDropdown.tsx
@@ -27,7 +27,16 @@ export function PortfoliosDropdown() {
   };
 
   const onPortfolioAddClick = () => {
+    if (!user) {
+      navigate(Routes.SIGNIN);
+      return;
+    }
+
     setIsPortfolioAddDialogOpen(true);
+  };
+
+  const moveToPortfolioPage = () => {
+    navigate(user ? Routes.PORTFOLIOS : Routes.SIGNIN);
   };
 
   return (
@@ -49,9 +58,7 @@ export function PortfoliosDropdown() {
           </AsyncBoundary>
         )}
 
-        <DropdownItem
-          sx={fixedDropdownItemSx}
-          onClick={() => navigate(Routes.PORTFOLIOS)}>
+        <DropdownItem sx={fixedDropdownItemSx} onClick={moveToPortfolioPage}>
           포트폴리오로 이동
         </DropdownItem>
         <DropdownItem sx={fixedDropdownItemSx} onClick={onPortfolioAddClick}>


### PR DESCRIPTION
## 구현한 것
- "포트폴리오로 이동"을 한 뒤 뒤로가기하면 homepage로 안 돌아가고 signinpage에 머무르는 현상 수정
- 로그인이 안됐을 때는 "포트폴리오 추가"를 클릭하면 signinpage로 이동하도록 수정
- 로그인이 안되었을 때, StockPage에서 "관심 종목 설정", "알림 설정" 버튼 누를시 SigninPage로 이동하도록 수정

## BE에 요청 예정인 내용
- 로그인이 안되었을 때도 검색 가능하도록 token protection 제거