### PR TITLE
[feat] 공용 컴포넌트 TextButton, IconButton 구현

### DIFF
--- a/src/api/stock/index.ts
+++ b/src/api/stock/index.ts
@@ -26,7 +26,7 @@ export type StockItem = {
 
 export const postStockSearch = async (query: string) => {
   const res = await fetcher.post<Response<StockSearchItem[]>>(
-    `/stocks/search/`,
+    `/stocks/search`,
     { searchTerm: query }
   );
   return res.data;

--- a/src/components/common/Buttons/Button.tsx
+++ b/src/components/common/Buttons/Button.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import styled from "styled-components";
 
-export type Variant = "primary" | "secondary" | "tertiary" | "text";
+export type Variant = "primary" | "secondary" | "tertiary";
 type Size = "h24" | "h32" | "h44";
 
 type Props = {
@@ -99,8 +99,6 @@ const StyledButton = styled.button<{
         return $disabled
           ? designSystem.color.neutral.gray50
           : designSystem.color.neutral.white;
-      case "text":
-        return "inherit";
       default:
         throw new Error("버튼 타입이 잘못되었습니다.");
     }
@@ -118,8 +116,6 @@ const StyledButton = styled.button<{
         return $disabled
           ? `1px solid ${designSystem.color.neutral.gray400}`
           : `1px solid ${designSystem.color.neutral.gray600}`;
-      case "text":
-        return "none";
       default:
         throw new Error("버튼 타입이 잘못되었습니다.");
     }
@@ -144,10 +140,6 @@ const StyledButton = styled.button<{
         return $disabled
           ? designSystem.color.neutral.gray400
           : designSystem.color.neutral.gray600;
-      case "text":
-        return $disabled
-          ? designSystem.color.neutral.gray600
-          : designSystem.color.neutral.white;
       default:
         throw new Error("버튼 타입이 잘못되었습니다.");
     }
@@ -165,8 +157,6 @@ const StyledButton = styled.button<{
           return designSystem.color.primary.blue50;
         case "tertiary":
           return designSystem.color.neutral.gray50;
-        case "text":
-          return $disabled ? "inherit" : designSystem.color.neutral.gray800;
         default:
           throw new Error("버튼 타입이 잘못되었습니다.");
       }

--- a/src/components/common/Buttons/IconButton.tsx
+++ b/src/components/common/Buttons/IconButton.tsx
@@ -1,0 +1,127 @@
+import { colors } from "@styles/designSystem";
+import { MouseEvent, useState } from "react";
+import styled from "styled-components";
+import { Icon, IconType } from "../Icon";
+
+type DesignSystemColorType = keyof typeof colors;
+
+type SizeType = "h24" | "h40";
+
+type DefaultColorType = "primary" | "gray" | "white";
+
+type ColorObjectType = {
+  iconColor: DesignSystemColorType;
+  hoverColor: DesignSystemColorType;
+};
+
+type DefaultProps = {
+  icon: IconType;
+  iconColor?: DefaultColorType;
+  hoverIconColor?: DesignSystemColorType;
+  hoverIcon?: IconType;
+  size: SizeType;
+  type?: "button" | "submit";
+  disabled?: boolean;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+};
+
+type CustomProps = {
+  icon: IconType;
+  iconColor: "custom";
+  hoverIconColor?: DesignSystemColorType;
+  hoverIcon?: IconType;
+  customColor: ColorObjectType;
+  size: SizeType;
+  type?: "button" | "submit";
+  disabled?: boolean;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+};
+
+type Props = DefaultProps | CustomProps;
+
+type ColorTableType = Record<DefaultColorType, ColorObjectType>;
+
+export function IconButton(props: Props) {
+  const {
+    icon,
+    iconColor = "primary",
+    size,
+    type,
+    disabled = false,
+    hoverIcon,
+    hoverIconColor,
+    onClick,
+  } = props;
+
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsHovered(false);
+  };
+
+  const colorTable: ColorTableType = {
+    primary: {
+      iconColor: "blue500",
+      hoverColor: "blue50",
+    },
+    gray: {
+      iconColor: "gray600",
+      hoverColor: "gray50",
+    },
+    white: {
+      iconColor: "white",
+      hoverColor: "gray800",
+    },
+  };
+
+  const colorObject =
+    iconColor === "custom" && "customColor" in props
+      ? props.customColor
+      : colorTable[iconColor as DefaultColorType];
+
+  return (
+    <StyledButton
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      $size={size}
+      $colorObject={colorObject}
+      $disabled={disabled}
+      disabled={disabled}
+      type={type}
+      onClick={onClick}>
+      <Icon
+        icon={isHovered && hoverIcon ? hoverIcon : icon}
+        size={size === "h24" ? 16 : 24}
+        color={
+          isHovered && hoverIconColor ? hoverIconColor : colorObject.iconColor
+        }
+      />
+    </StyledButton>
+  );
+}
+
+const StyledButton = styled.button<{
+  $size: SizeType;
+  $colorObject: {
+    iconColor: DesignSystemColorType;
+    hoverColor: DesignSystemColorType;
+  };
+  $disabled: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${({ $size }) => ($size === "h24" ? "24px" : "40px")};
+  height: ${({ $size }) => ($size === "h24" ? "24px" : "40px")};
+  border-radius: 4px;
+  color: ${({ $colorObject }) => colors[$colorObject.iconColor]};
+  ${({ $disabled }) => $disabled && "opacity: 0.5;"}
+
+  &:hover {
+    background-color: ${({ $colorObject }) => colors[$colorObject.hoverColor]};
+  }
+`;

--- a/src/components/common/Buttons/IconButton.tsx
+++ b/src/components/common/Buttons/IconButton.tsx
@@ -1,23 +1,15 @@
-import { colors } from "@styles/designSystem";
+import { ColorType, getColor } from "@styles/designSystem";
 import { MouseEvent, useState } from "react";
 import styled from "styled-components";
 import { Icon, IconType } from "../Icon";
-
-type DesignSystemColorType = keyof typeof colors;
+import { ColorObjectType, ColorTableType, DefaultColorType } from "./types";
 
 type SizeType = "h24" | "h40";
-
-type DefaultColorType = "primary" | "gray" | "white";
-
-type ColorObjectType = {
-  iconColor: DesignSystemColorType;
-  hoverColor: DesignSystemColorType;
-};
 
 type DefaultProps = {
   icon: IconType;
   iconColor?: DefaultColorType;
-  hoverIconColor?: DesignSystemColorType;
+  hoverIconColor?: ColorType;
   hoverIcon?: IconType;
   size: SizeType;
   type?: "button" | "submit";
@@ -28,7 +20,7 @@ type DefaultProps = {
 type CustomProps = {
   icon: IconType;
   iconColor: "custom";
-  hoverIconColor?: DesignSystemColorType;
+  hoverIconColor?: ColorType;
   hoverIcon?: IconType;
   customColor: ColorObjectType;
   size: SizeType;
@@ -38,8 +30,6 @@ type CustomProps = {
 };
 
 type Props = DefaultProps | CustomProps;
-
-type ColorTableType = Record<DefaultColorType, ColorObjectType>;
 
 export function IconButton(props: Props) {
   const {
@@ -65,15 +55,15 @@ export function IconButton(props: Props) {
 
   const colorTable: ColorTableType = {
     primary: {
-      iconColor: "blue500",
+      color: "blue500",
       hoverColor: "blue50",
     },
     gray: {
-      iconColor: "gray600",
+      color: "gray600",
       hoverColor: "gray50",
     },
     white: {
-      iconColor: "white",
+      color: "white",
       hoverColor: "gray800",
     },
   };
@@ -96,9 +86,7 @@ export function IconButton(props: Props) {
       <Icon
         icon={isHovered && hoverIcon ? hoverIcon : icon}
         size={size === "h24" ? 16 : 24}
-        color={
-          isHovered && hoverIconColor ? hoverIconColor : colorObject.iconColor
-        }
+        color={isHovered && hoverIconColor ? hoverIconColor : colorObject.color}
       />
     </StyledButton>
   );
@@ -107,8 +95,8 @@ export function IconButton(props: Props) {
 const StyledButton = styled.button<{
   $size: SizeType;
   $colorObject: {
-    iconColor: DesignSystemColorType;
-    hoverColor: DesignSystemColorType;
+    color: ColorType;
+    hoverColor: ColorType;
   };
   $disabled: boolean;
 }>`
@@ -118,10 +106,11 @@ const StyledButton = styled.button<{
   width: ${({ $size }) => ($size === "h24" ? "24px" : "40px")};
   height: ${({ $size }) => ($size === "h24" ? "24px" : "40px")};
   border-radius: 4px;
-  color: ${({ $colorObject }) => colors[$colorObject.iconColor]};
+  color: ${({ $colorObject }) => getColor($colorObject.color)};
   ${({ $disabled }) => $disabled && "opacity: 0.5;"}
 
   &:hover {
-    background-color: ${({ $colorObject }) => colors[$colorObject.hoverColor]};
+    background-color: ${({ $colorObject }) =>
+      getColor($colorObject.hoverColor)};
   }
 `;

--- a/src/components/common/Buttons/TextButton.tsx
+++ b/src/components/common/Buttons/TextButton.tsx
@@ -1,19 +1,11 @@
-import designSystem, { colors } from "@styles/designSystem";
+import { ColorType, getColor } from "@styles/designSystem";
 import { MouseEvent, ReactNode } from "react";
 import styled from "styled-components";
-
-type DesignSystemColorType = keyof typeof colors;
+import { ColorObjectType, ColorTableType, DefaultColorType } from "./types";
 
 type SizeType = "h24" | "h32";
 
 type VariantType = "default" | "underline";
-
-type DefaultColorType = "primary" | "gray" | "white";
-
-type CustomColorType = {
-  color: DesignSystemColorType;
-  hoverColor: DesignSystemColorType;
-};
 
 type DefaultProps = {
   variant?: VariantType;
@@ -28,7 +20,7 @@ type DefaultProps = {
 type CustomProps = {
   variant?: VariantType;
   color: "custom";
-  customColor: CustomColorType;
+  customColor: ColorObjectType;
   size: SizeType;
   children: ReactNode;
   type?: "button" | "submit";
@@ -49,24 +41,24 @@ export function TextButton(props: Props) {
     onClick,
   } = props;
 
-  const colorTable = {
+  const colorTable: ColorTableType = {
     primary: {
-      color: designSystem.color.primary.blue500,
-      hoverColor: designSystem.color.primary.blue50,
+      color: "blue500",
+      hoverColor: "blue50",
     },
     gray: {
-      color: designSystem.color.neutral.gray600,
-      hoverColor: designSystem.color.neutral.gray50,
+      color: "gray600",
+      hoverColor: "gray50",
     },
     white: {
-      color: designSystem.color.neutral.white,
-      hoverColor: designSystem.color.neutral.gray800,
+      color: "white",
+      hoverColor: "gray800",
     },
   };
 
   const colorObject =
     color === "custom" && "customColor" in props
-      ? getCustomColorTable(props.customColor)
+      ? props.customColor
       : colorTable[color as DefaultColorType];
 
   return (
@@ -83,19 +75,12 @@ export function TextButton(props: Props) {
   );
 }
 
-const getCustomColorTable = (customColor: CustomColorType) => {
-  return {
-    color: colors[customColor.color],
-    hoverColor: colors[customColor.hoverColor],
-  };
-};
-
 const StyledButton = styled.button<{
   $size: SizeType;
   $variant: VariantType;
   $colorObject: {
-    color: string;
-    hoverColor: string;
+    color: ColorType;
+    hoverColor: ColorType;
   };
   $disabled: boolean;
 }>`
@@ -107,13 +92,13 @@ const StyledButton = styled.button<{
   height: ${({ $size }) => ($size === "h24" ? "24px" : "32px")};
   padding-inline: ${({ $size }) => ($size === "h24" ? "8px" : "12px")};
   border-radius: ${({ $size }) => ($size === "h24" ? "2px" : "3px")};
-  color: ${({ $colorObject }) => $colorObject.color};
+  color: ${({ $colorObject }) => getColor($colorObject.color)};
   ${({ $disabled }) => $disabled && "opacity: 0.5;"}
 
   &:hover {
     ${({ $variant, $colorObject }) =>
       $variant === "default"
-        ? `background-color: ${$colorObject.hoverColor};`
+        ? `background-color: ${getColor($colorObject.hoverColor)};`
         : "text-decoration: underline;"}
   }
 `;

--- a/src/components/common/Buttons/TextButton.tsx
+++ b/src/components/common/Buttons/TextButton.tsx
@@ -1,0 +1,119 @@
+import designSystem, { colors } from "@styles/designSystem";
+import { MouseEvent, ReactNode } from "react";
+import styled from "styled-components";
+
+type DesignSystemColorType = keyof typeof colors;
+
+type SizeType = "h24" | "h32";
+
+type VariantType = "default" | "underline";
+
+type DefaultColorType = "primary" | "gray" | "white";
+
+type CustomColorType = {
+  color: DesignSystemColorType;
+  hoverColor: DesignSystemColorType;
+};
+
+type DefaultProps = {
+  variant?: VariantType;
+  color?: DefaultColorType;
+  size: SizeType;
+  children: ReactNode;
+  type?: "button" | "submit";
+  disabled?: boolean;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+};
+
+type CustomProps = {
+  variant?: VariantType;
+  color: "custom";
+  customColor: CustomColorType;
+  size: SizeType;
+  children: ReactNode;
+  type?: "button" | "submit";
+  disabled?: boolean;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+};
+
+type Props = DefaultProps | CustomProps;
+
+export function TextButton(props: Props) {
+  const {
+    variant = "default",
+    color = "primary",
+    size,
+    children,
+    type,
+    disabled = false,
+    onClick,
+  } = props;
+
+  const colorTable = {
+    primary: {
+      color: designSystem.color.primary.blue500,
+      hoverColor: designSystem.color.primary.blue50,
+    },
+    gray: {
+      color: designSystem.color.neutral.gray600,
+      hoverColor: designSystem.color.neutral.gray50,
+    },
+    white: {
+      color: designSystem.color.neutral.white,
+      hoverColor: designSystem.color.neutral.gray800,
+    },
+  };
+
+  const colorObject =
+    color === "custom" && "customColor" in props
+      ? getCustomColorTable(props.customColor)
+      : colorTable[color as DefaultColorType];
+
+  return (
+    <StyledButton
+      $variant={variant}
+      $size={size}
+      $colorObject={colorObject}
+      $disabled={disabled}
+      disabled={disabled}
+      type={type}
+      onClick={onClick}>
+      {children}
+    </StyledButton>
+  );
+}
+
+const getCustomColorTable = (customColor: CustomColorType) => {
+  return {
+    color: colors[customColor.color],
+    hoverColor: colors[customColor.hoverColor],
+  };
+};
+
+const StyledButton = styled.button<{
+  $size: SizeType;
+  $variant: VariantType;
+  $colorObject: {
+    color: string;
+    hoverColor: string;
+  };
+  $disabled: boolean;
+}>`
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+  min-width: ${({ $size }) => ($size === "h24" ? "56px" : "80px")};
+  height: ${({ $size }) => ($size === "h24" ? "24px" : "32px")};
+  padding-inline: ${({ $size }) => ($size === "h24" ? "8px" : "12px")};
+  border-radius: ${({ $size }) => ($size === "h24" ? "2px" : "3px")};
+  color: ${({ $colorObject }) => $colorObject.color};
+  ${({ $disabled }) => $disabled && "opacity: 0.5;"}
+
+  &:hover {
+    ${({ $variant, $colorObject }) =>
+      $variant === "default"
+        ? `background-color: ${$colorObject.hoverColor};`
+        : "text-decoration: underline;"}
+  }
+`;

--- a/src/components/common/Buttons/types.ts
+++ b/src/components/common/Buttons/types.ts
@@ -1,0 +1,10 @@
+import { ColorType } from "@styles/designSystem";
+
+export type DefaultColorType = "primary" | "gray" | "white";
+
+export type ColorObjectType = {
+  color: ColorType;
+  hoverColor: ColorType;
+};
+
+export type ColorTableType = Record<DefaultColorType, ColorObjectType>;

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -8,6 +8,7 @@ import { NavBar } from "../../NavBar";
 import SearchBar from "../../SearchBar/SearchBar";
 import TVTickerTapeWidget from "../../TradingViewWidgets/TVTickerTape";
 import Button from "../Buttons/Button";
+import { TextButton } from "../Buttons/TextButton";
 import { PortfoliosDropdown } from "./PortfoliosDropdown/PortfoliosDropdown";
 import UserControls from "./UserControls";
 
@@ -59,9 +60,9 @@ export default function Header() {
             <UserControls user={user} />
           ) : (
             <ButtonWrapper>
-              <Button variant="text" size="h32" onClick={moveToSignInPage}>
+              <TextButton size="h32" color="white" onClick={moveToSignInPage}>
                 로그인
-              </Button>
+              </TextButton>
               <Button variant="primary" size="h32" onClick={moveToSignUpPage}>
                 회원가입
               </Button>

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -38,10 +38,12 @@ import upIcon from "@assets/icons/ic_up.svg";
 import userIcon from "@assets/icons/ic_user.svg";
 import warningIcon from "@assets/icons/ic_warning.svg";
 
-import { colors } from "@styles/designSystem";
+import {
+  ColorType,
+  DesignSystemColorType,
+  getColor,
+} from "@styles/designSystem";
 import { styled } from "styled-components";
-
-type ColorType = keyof typeof colors;
 
 type IconSize = 12 | 16 | 24 | 32 | 48;
 
@@ -49,7 +51,7 @@ type Props = {
   size: IconSize;
   icon: IconType;
   color: ColorType;
-  hoverColor?: ColorType;
+  hoverColor?: DesignSystemColorType;
 };
 
 const icons = {
@@ -99,12 +101,14 @@ export type IconType = keyof typeof icons;
 export function Icon({ size, icon, color, hoverColor }: Props) {
   const iconUrl = icons[icon];
 
+  const colorValue = getColor(color);
+
   return (
     <StyledIcon
       className="icon"
       $size={size}
       $iconUrl={iconUrl}
-      $color={colors[color]}
+      $color={colorValue}
       $hoverColor={hoverColor}
     />
   );

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -94,7 +94,7 @@ const icons = {
   "warning": warningIcon,
 };
 
-type IconType = keyof typeof icons;
+export type IconType = keyof typeof icons;
 
 export function Icon({ size, icon, color, hoverColor }: Props) {
   const iconUrl = icons[icon];

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -38,11 +38,7 @@ import upIcon from "@assets/icons/ic_up.svg";
 import userIcon from "@assets/icons/ic_user.svg";
 import warningIcon from "@assets/icons/ic_warning.svg";
 
-import {
-  ColorType,
-  DesignSystemColorType,
-  getColor,
-} from "@styles/designSystem";
+import { ColorType, getColor } from "@styles/designSystem";
 import { styled } from "styled-components";
 
 type IconSize = 12 | 16 | 24 | 32 | 48;
@@ -51,7 +47,7 @@ type Props = {
   size: IconSize;
   icon: IconType;
   color: ColorType;
-  hoverColor?: DesignSystemColorType;
+  hoverColor?: ColorType;
 };
 
 const icons = {

--- a/src/styles/designSystem.ts
+++ b/src/styles/designSystem.ts
@@ -151,3 +151,36 @@ export default {
 
   font,
 };
+
+type RGB =
+  | `rgb(${number}, ${number}, ${number})`
+  | `rgb(${number},${number},${number})`;
+
+type RGBA =
+  | `rgba(${number}, ${number}, ${number}, ${number})`
+  | `rgba(${number},${number},${number},${number})`;
+
+type HEX = `#${string}`;
+
+export type DesignSystemColorType = keyof typeof colors;
+
+export type ColorType = DesignSystemColorType | RGB | RGBA | HEX;
+
+export function validateColor(color: ColorType): boolean {
+  const colorRegex =
+    /^(#([A-Fa-f0-9]{6}([A-Fa-f0-9]{2})?|[A-Fa-f0-9]{3})|rgb\s*\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)|rgba\s*\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*(0|1|0?\.\d+)\s*\))$/;
+
+  return colorRegex.test(color);
+}
+
+export function getColor(color: ColorType) {
+  const colorValue = colors[color as DesignSystemColorType];
+
+  if (validateColor(color)) {
+    return color;
+  } else if (colorValue) {
+    return colorValue;
+  }
+
+  throw new Error(`"${color}"은 유효하지 않은 색상 값입니다.`);
+}

--- a/src/styles/designSystem.ts
+++ b/src/styles/designSystem.ts
@@ -176,10 +176,10 @@ export function validateColor(color: ColorType): boolean {
 export function getColor(color: ColorType) {
   const colorValue = colors[color as DesignSystemColorType];
 
-  if (validateColor(color)) {
-    return color;
-  } else if (colorValue) {
+  if (colorValue) {
     return colorValue;
+  } else if (validateColor(color)) {
+    return color;
   }
 
   throw new Error(`"${color}"은 유효하지 않은 색상 값입니다.`);


### PR DESCRIPTION
## 구현한 것
- #161 


## 사용처 예시
```tsx
<TextButton size="h24" disabled>
  hi
</TextButton>

<TextButton size="h24" color="gray">
  <Icon size={16} icon="add" color="gray600" />
  hi
</TextButton>

<TextButton size="h24" color="white">
  hi
</TextButton>

<TextButton size="h24" variant="underline">
  hi
</TextButton>

<TextButton
  size="h24"
  color="custom"
  customColor={{ color: "red500", hoverColor: "red50" }}>
  hi
</TextButton>

<IconButton
  icon="add"
  size="h24"
  hoverIconColor="red500"
  hoverIcon="arrow-left"
/>

<IconButton icon="add" size="h40" hoverIconColor="red500" />
```