### PR TITLE
[refactor] 포트폴리오 페이지 버그 리팩터링

### DIFF
--- a/src/api/hooks/useSSE.tsx
+++ b/src/api/hooks/useSSE.tsx
@@ -31,6 +31,15 @@ export function useSSE<T>({ url, eventTypeName }: Props) {
 
   const eventSourceRef = useRef<EventSourcePolyfill>();
 
+  const onClose = useCallback(() => {
+    setData(undefined);
+    setIsLoading(true);
+    setIsError(false);
+    setShouldReconnect(true);
+
+    eventSourceRef.current?.close();
+  }, []);
+
   const messageListener = useMemo(
     () => ({
       handleEvent: (event: MessageEvent) => {
@@ -52,7 +61,7 @@ export function useSSE<T>({ url, eventTypeName }: Props) {
         onClose();
       },
     }),
-    []
+    [onClose]
   );
 
   const initEventSource = useCallback(() => {
@@ -86,6 +95,13 @@ export function useSSE<T>({ url, eventTypeName }: Props) {
     eventSourceRef.current.addEventListener("complete", completeHandler);
   }, [url, eventTypeName, messageListener, completeHandler]);
 
+  const reconnect = useCallback(() => {
+    onClose();
+    setIsError(false);
+    setIsLoading(true);
+    initEventSource();
+  }, [onClose, initEventSource]);
+
   useEffect(() => {
     if (!shouldReconnect) return;
 
@@ -94,18 +110,7 @@ export function useSSE<T>({ url, eventTypeName }: Props) {
 
   useEffect(() => {
     return onClose;
-  }, []);
+  }, [onClose]);
 
-  const onClose = () => {
-    eventSourceRef.current?.close();
-  };
-
-  const reconnect = () => {
-    onClose();
-    setIsError(false);
-    setIsLoading(true);
-    initEventSource();
-  };
-
-  return { data, isLoading, isError, reconnect };
+  return { data, isLoading, isError, reconnect, onClose };
 }

--- a/src/components/Portfolio/MainPanel.tsx
+++ b/src/components/Portfolio/MainPanel.tsx
@@ -2,6 +2,7 @@ import { useSSE } from "@api/hooks/useSSE";
 import usePortfolioDetailsQuery from "@api/portfolio/queries/usePortfolioDetailsQuery";
 import { PortfolioSSE } from "@api/portfolio/types";
 import { Box } from "@mui/material";
+import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import EmptyPortfolioHoldingTable from "./PortfolioHolding/EmptyPortfolioHoldingTable";
@@ -16,11 +17,16 @@ export default function MainPanel() {
     data: portfolioSSE,
     isLoading,
     isError,
+    onClose,
     //TODO: SSE 에러일때 핸들링처리
   } = useSSE<PortfolioSSE>({
     url: `/api/portfolio/${portfolioId}/holdings/realtime`,
     eventTypeName: "portfolioDetails",
   });
+
+  useEffect(() => {
+    return onClose;
+  }, [portfolioId, onClose]);
 
   // Static Data
   const { portfolioDetails, portfolioHoldings } = portfolio;


### PR DESCRIPTION
## 구현한 것
- #161 

## 해결한 내용
#### 포트폴리오 전환 시  "평가 금액"과 총 손익" 데이터가 이전 포트폴리오 "평가 금액" 및 "총 손익"이 남아있는 문제 
- SSE 데이터가 reset되지 않아 생기는 문제로 해결

#### SSE 연결이 여러 포트폴리오 값으로 열려 있어 계속 여러 포트폴리오 값으로 깜빡이는 문제
- 메인 패널 컴포넌트에서 클린업으로 SSE 연결을 Close하여 해결

#### 백엔드에서 SSE 연결 방식 변경 사항
- 따로 프론트에서 수정할 사항이 없었음