### PR TITLE
[refactor] : 포트폴리오 페이지 실시간 데이터 변경에 따른 색상 변경 리팩터링

### DIFF
--- a/src/components/Portfolio/PortfolioHolding/PortfolioHoldingRow.tsx
+++ b/src/components/Portfolio/PortfolioHolding/PortfolioHoldingRow.tsx
@@ -135,22 +135,14 @@ export default function PortfolioHoldingRow({
           <RealtimeValue value={dailyChange}>
             ₩{thousandsDelimiter(dailyChange)}
           </RealtimeValue>
-          <RateBadge
-            size={12}
-            value={dailyChangeRate ?? dailyChangeRate}
-            bgColorStatus={false}
-          />
+          <RateBadge size={12} value={dailyChangeRate} bgColorStatus={false} />
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
           <RealtimeValue value={totalGain}>
             ₩{thousandsDelimiter(totalGain)}
           </RealtimeValue>
-          <RateBadge
-            size={12}
-            value={totalReturnRate ?? totalReturnRate}
-            bgColorStatus={false}
-          />
+          <RateBadge size={12} value={totalReturnRate} bgColorStatus={false} />
         </HoldingTableCell>
 
         <HoldingTableCell

--- a/src/components/Portfolio/PortfolioHolding/PortfolioHoldingRow.tsx
+++ b/src/components/Portfolio/PortfolioHolding/PortfolioHoldingRow.tsx
@@ -1,25 +1,15 @@
-import { PortfolioHolding, PortfolioHoldingsSSE } from "@api/portfolio/types";
+import { PortfolioHolding } from "@api/portfolio/types";
 import RateBadge from "@components/common/Badges/RateBadge";
 import { IconButton } from "@components/common/Buttons/IconButton";
 import CheckBox from "@components/common/Checkbox/Checkbox";
+import RealtimeValue from "@components/common/RealtimeValue";
 import { thousandsDelimiter } from "@fineants/demolition";
 import { Collapse, TableCell, TableRow, Typography } from "@mui/material";
 import designSystem from "@styles/designSystem";
-import { MouseEvent, useCallback, useEffect, useRef, useState } from "react";
+import { MouseEvent, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import styled from "styled-components";
 import PortfolioHoldingLotsTable from "./PortfolioHoldingLots/PortfolioHoldingLotsTable";
-
-type GainOrLoss = "gain" | "loss" | "none";
-
-type ChangeStatus = {
-  currentValuation: GainOrLoss;
-  currentPrice: GainOrLoss;
-  dailyChange: GainOrLoss;
-  dailyChangeRate: GainOrLoss;
-  totalGain: GainOrLoss;
-  totalReturnRate: GainOrLoss;
-};
 
 type Props = {
   labelId: string;
@@ -56,65 +46,6 @@ export default function PortfolioHoldingRow({
   } = row;
 
   const [isRowOpen, setIsRowOpen] = useState(false);
-  const [changeStatus, setChangeStatus] = useState<ChangeStatus>({
-    currentValuation: "none",
-    currentPrice: "none",
-    dailyChange: "none",
-    dailyChangeRate: "none",
-    totalGain: "none",
-    totalReturnRate: "none",
-  });
-
-  const prevValues = useRef<PortfolioHoldingsSSE>({
-    currentValuation: currentValuation,
-    currentPrice: currentPrice,
-    dailyChange: dailyChange,
-    dailyChangeRate: dailyChangeRate,
-    totalGain: totalGain,
-    totalReturnRate: totalReturnRate,
-  });
-
-  const checkValuesChange = useCallback(
-    (key: keyof PortfolioHoldingsSSE): GainOrLoss => {
-      const currentValue = row[key];
-      const previousValue = prevValues.current[key];
-
-      if (currentValue > previousValue) {
-        return "gain"; // 값이 증가했음
-      } else if (currentValue < previousValue) {
-        return "loss"; // 값이 감소했음
-      } else {
-        return "none"; // 값이 동일함
-      }
-    },
-    [row]
-  );
-
-  const resyncValues = useCallback(() => {
-    setChangeStatus({
-      currentValuation: "none",
-      currentPrice: "none",
-      dailyChange: "none",
-      dailyChangeRate: "none",
-      totalGain: "none",
-      totalReturnRate: "none",
-    });
-    prevValues.current = {
-      currentValuation: currentValuation,
-      currentPrice: currentPrice,
-      dailyChange: dailyChange,
-      dailyChangeRate: dailyChangeRate,
-      totalGain: totalGain,
-      totalReturnRate: totalReturnRate,
-    };
-  }, [
-    currentValuation,
-    currentPrice,
-    dailyChange,
-    dailyChangeRate,
-    totalGain,
-    totalReturnRate,
-  ]);
 
   const onExpandRowClick = (
     event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>
@@ -122,33 +53,6 @@ export default function PortfolioHoldingRow({
     event.stopPropagation();
     setIsRowOpen(!isRowOpen);
   };
-
-  useEffect(() => {
-    const newStatus = {
-      currentValuation: checkValuesChange("currentValuation"),
-      currentPrice: checkValuesChange("currentPrice"),
-      dailyChange: checkValuesChange("dailyChange"),
-      dailyChangeRate: checkValuesChange("dailyChangeRate"),
-      totalGain: checkValuesChange("totalGain"),
-      totalReturnRate: checkValuesChange("totalReturnRate"),
-    };
-    setChangeStatus(newStatus);
-
-    const timer = setTimeout(resyncValues, 2500);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [
-    checkValuesChange,
-    currentPrice,
-    currentValuation,
-    dailyChange,
-    dailyChangeRate,
-    totalGain,
-    totalReturnRate,
-    resyncValues,
-  ]);
 
   // TODO: Reduce rendering (currently renders twice)
   useEffect(() => {
@@ -208,15 +112,15 @@ export default function PortfolioHoldingRow({
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
-          <ChangeableAmount $gainOrLoss={changeStatus.currentValuation}>
-            ₩{thousandsDelimiter(currentValuation ?? currentValuation)}
-          </ChangeableAmount>
+          <RealtimeValue value={currentValuation}>
+            ₩{thousandsDelimiter(currentValuation)}
+          </RealtimeValue>
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
-          <ChangeableAmount $gainOrLoss={changeStatus.currentPrice}>
-            ₩{thousandsDelimiter(currentPrice ?? currentPrice)}
-          </ChangeableAmount>
+          <RealtimeValue value={currentPrice}>
+            ₩{thousandsDelimiter(currentPrice)}
+          </RealtimeValue>
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
@@ -228,9 +132,9 @@ export default function PortfolioHoldingRow({
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "80px" }} align="right">
-          <ChangeableAmount $gainOrLoss={changeStatus.dailyChange}>
-            {thousandsDelimiter(dailyChange ?? dailyChange)}
-          </ChangeableAmount>
+          <RealtimeValue value={dailyChange}>
+            ₩{thousandsDelimiter(dailyChange)}
+          </RealtimeValue>
           <RateBadge
             size={12}
             value={dailyChangeRate ?? dailyChangeRate}
@@ -239,9 +143,9 @@ export default function PortfolioHoldingRow({
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
-          <ChangeableAmount $gainOrLoss={changeStatus.totalGain}>
-            ₩{thousandsDelimiter(totalGain ?? totalGain)}
-          </ChangeableAmount>
+          <RealtimeValue value={totalGain}>
+            ₩{thousandsDelimiter(totalGain)}
+          </RealtimeValue>
           <RateBadge
             size={12}
             value={totalReturnRate ?? totalReturnRate}
@@ -320,21 +224,4 @@ const Amount = styled(HoldingTypography)`
 
 const StyledHoldingLotRow = styled(TableRow)`
   width: 856px;
-`;
-
-const ChangeableAmount = styled(Amount)<{
-  $gainOrLoss: GainOrLoss;
-}>`
-  color: ${({ $gainOrLoss, theme: { color } }) => {
-    switch ($gainOrLoss) {
-      case "none":
-        return color.neutral.gray900;
-      case "gain":
-        return color.state.green500;
-      case "loss":
-        return color.state.red500;
-      default:
-        return color.neutral.gray900;
-    }
-  }};
 `;

--- a/src/components/Portfolio/PortfolioHolding/PortfolioHoldingRow.tsx
+++ b/src/components/Portfolio/PortfolioHolding/PortfolioHoldingRow.tsx
@@ -112,15 +112,11 @@ export default function PortfolioHoldingRow({
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
-          <RealtimeValue value={currentValuation}>
-            ₩{thousandsDelimiter(currentValuation)}
-          </RealtimeValue>
+          <RealtimeValue value={currentValuation} />
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
-          <RealtimeValue value={currentPrice}>
-            ₩{thousandsDelimiter(currentPrice)}
-          </RealtimeValue>
+          <RealtimeValue value={currentPrice} />
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
@@ -132,16 +128,12 @@ export default function PortfolioHoldingRow({
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "80px" }} align="right">
-          <RealtimeValue value={dailyChange}>
-            ₩{thousandsDelimiter(dailyChange)}
-          </RealtimeValue>
+          <RealtimeValue value={dailyChange} />
           <RateBadge size={12} value={dailyChangeRate} bgColorStatus={false} />
         </HoldingTableCell>
 
         <HoldingTableCell style={{ width: "108px" }} align="right">
-          <RealtimeValue value={totalGain}>
-            ₩{thousandsDelimiter(totalGain)}
-          </RealtimeValue>
+          <RealtimeValue value={totalGain} />
           <RateBadge size={12} value={totalReturnRate} bgColorStatus={false} />
         </HoldingTableCell>
 

--- a/src/components/Portfolio/PortfolioOverview/PortfolioOverviewBody.tsx
+++ b/src/components/Portfolio/PortfolioOverview/PortfolioOverviewBody.tsx
@@ -128,9 +128,7 @@ export default function PortfolioOverviewBody({ data }: Props) {
         <OverviewBodySection>
           <OverviewBodyData>
             <div>총 손익</div>
-            <RealtimeValue value={data.totalGain}>
-              ₩{thousandsDelimiter(data.totalGain)}
-            </RealtimeValue>
+            <RealtimeValue value={data.totalGain} />
           </OverviewBodyData>
           <div style={{ marginLeft: "auto" }}>
             <RateBadge
@@ -142,9 +140,7 @@ export default function PortfolioOverviewBody({ data }: Props) {
           </div>
           <OverviewBodyData>
             <div>당일 손익</div>
-            <RealtimeValue value={data.dailyGain}>
-              ₩{thousandsDelimiter(data.dailyGain)}
-            </RealtimeValue>
+            <RealtimeValue value={data.dailyGain} />
           </OverviewBodyData>
           <div style={{ marginLeft: "auto" }}>
             <RateBadge

--- a/src/components/Portfolio/PortfolioOverview/PortfolioOverviewBody.tsx
+++ b/src/components/Portfolio/PortfolioOverview/PortfolioOverviewBody.tsx
@@ -4,6 +4,7 @@ import RateBadge from "@components/common/Badges/RateBadge";
 import { IconButton } from "@components/common/Buttons/IconButton";
 import { CustomTooltip } from "@components/common/CustomTooltip";
 import { Icon } from "@components/common/Icon";
+import RealtimeValue from "@components/common/RealtimeValue";
 import { thousandsDelimiter } from "@fineants/demolition";
 import { debounce } from "@mui/material";
 import designSystem from "@styles/designSystem";
@@ -127,7 +128,9 @@ export default function PortfolioOverviewBody({ data }: Props) {
         <OverviewBodySection>
           <OverviewBodyData>
             <div>총 손익</div>
-            <span>₩{thousandsDelimiter(data.totalGain)}</span>
+            <RealtimeValue value={data.totalGain}>
+              ₩{thousandsDelimiter(data.totalGain)}
+            </RealtimeValue>
           </OverviewBodyData>
           <div style={{ marginLeft: "auto" }}>
             <RateBadge
@@ -139,7 +142,9 @@ export default function PortfolioOverviewBody({ data }: Props) {
           </div>
           <OverviewBodyData>
             <div>당일 손익</div>
-            <span>₩{thousandsDelimiter(data.dailyGain)}</span>
+            <RealtimeValue value={data.dailyGain}>
+              ₩{thousandsDelimiter(data.dailyGain)}
+            </RealtimeValue>
           </OverviewBodyData>
           <div style={{ marginLeft: "auto" }}>
             <RateBadge

--- a/src/components/common/RealtimeValue.tsx
+++ b/src/components/common/RealtimeValue.tsx
@@ -1,15 +1,15 @@
+import { thousandsDelimiter } from "@fineants/demolition";
 import designSystem from "@styles/designSystem";
-import { ReactNode, memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 
 type Props = {
   value: number;
-  children: ReactNode;
 };
 
 type ValueStatus = "gain" | "loss" | "none";
 
-export default memo(function RealtimeValue({ value, children }: Props) {
+export default memo(function RealtimeValue({ value }: Props) {
   const prevValue = useRef(value);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -44,7 +44,9 @@ export default memo(function RealtimeValue({ value, children }: Props) {
     };
   }, [status]);
 
-  return <StyledPrice $status={status}>{children}</StyledPrice>;
+  return (
+    <StyledPrice $status={status}>₩{thousandsDelimiter(value)}</StyledPrice>
+  );
 });
 
 const StyledPrice = styled.span<{ $status: ValueStatus }>`

--- a/src/components/common/RealtimeValue.tsx
+++ b/src/components/common/RealtimeValue.tsx
@@ -52,12 +52,12 @@ export default memo(function RealtimeValue({ value }: Props) {
 const StyledPrice = styled.span<{ $status: ValueStatus }>`
   color: ${({ $status }) => {
     switch ($status) {
-      case "none":
-        return designSystem.color.neutral.gray900;
       case "gain":
         return designSystem.color.state.green500;
       case "loss":
         return designSystem.color.state.red500;
+      case "none":
+        return designSystem.color.neutral.gray900;
     }
   }};
 `;

--- a/src/components/common/RealtimeValue.tsx
+++ b/src/components/common/RealtimeValue.tsx
@@ -1,0 +1,61 @@
+import designSystem from "@styles/designSystem";
+import { ReactNode, memo, useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+
+type Props = {
+  value: number;
+  children: ReactNode;
+};
+
+type ValueStatus = "gain" | "loss" | "none";
+
+export default memo(function RealtimeValue({ value, children }: Props) {
+  const prevValue = useRef(value);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [status, setStatus] = useState<ValueStatus>("none");
+
+  useEffect(() => {
+    if (value > prevValue.current) {
+      setStatus("gain");
+    } else if (value < prevValue.current) {
+      setStatus("loss");
+    } else {
+      setStatus("none");
+    }
+
+    prevValue.current = value;
+  }, [value]);
+
+  useEffect(() => {
+    if (status !== "none") {
+      timerRef.current = setTimeout(() => {
+        setStatus("none");
+      }, 2500);
+    } else if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [status]);
+
+  return <StyledPrice $status={status}>{children}</StyledPrice>;
+});
+
+const StyledPrice = styled.span<{ $status: ValueStatus }>`
+  color: ${({ $status }) => {
+    switch ($status) {
+      case "none":
+        return designSystem.color.neutral.gray900;
+      case "gain":
+        return designSystem.color.state.green500;
+      case "loss":
+        return designSystem.color.state.red500;
+    }
+  }};
+`;


### PR DESCRIPTION
## 구현한 것
- #206 
- 기존 포트폴리오 홀딩 테이블의 body setTimeout 돌아가고 있어 불필요하게 큰 컴포넌트 하나가 재랜더링되고 `RealtimeValue` 컴포넌트를 만들어 해당 값만 재랜더링 되도록 변경

