### PR TITLE
[refactor] useZIndex hook 문제 해결

### DIFF
--- a/src/features/stock/components/mobile/StockActionDrawer.tsx
+++ b/src/features/stock/components/mobile/StockActionDrawer.tsx
@@ -58,14 +58,12 @@ export default function StockActionDrawer({
         </ul>
       </BottomDrawer>
 
-      {isWatchlistHasStockDrawerOpen && (
-        <WatchlistHasStockDrawer
-          tickerSymbol={tickerSymbol}
-          isOpen={isWatchlistHasStockDrawerOpen}
-          onOpen={onWatchlistHasStockDrawerOpen}
-          onClose={onWatchlistHasStockDrawerClose}
-        />
-      )}
+      <WatchlistHasStockDrawer
+        tickerSymbol={tickerSymbol}
+        isOpen={isWatchlistHasStockDrawerOpen}
+        onOpen={onWatchlistHasStockDrawerOpen}
+        onClose={onWatchlistHasStockDrawerClose}
+      />
 
       {isDialogOpen && (
         <TargetPriceAlertDialog isOpen={isDialogOpen} onClose={onDialogClose} />

--- a/src/features/stock/components/mobile/WatchlistHasStockDrawer/WatchlistHasStockDrawer.tsx
+++ b/src/features/stock/components/mobile/WatchlistHasStockDrawer/WatchlistHasStockDrawer.tsx
@@ -48,12 +48,10 @@ export default function WatchlistHasStockDrawer({
         </AsyncBoundary>
       </BottomDrawer>
 
-      {isNewWatchlistDialogOpen && (
-        <NewWatchlistDialog
-          isOpen={isNewWatchlistDialogOpen}
-          onClose={onNewWatchlistDialogClose}
-        />
-      )}
+      <NewWatchlistDialog
+        isOpen={isNewWatchlistDialogOpen}
+        onClose={onNewWatchlistDialogClose}
+      />
     </>
   );
 }

--- a/src/features/watchlist/components/dialog/mobile/NewWatchlistDialogM.tsx
+++ b/src/features/watchlist/components/dialog/mobile/NewWatchlistDialogM.tsx
@@ -36,7 +36,6 @@ export default function NewWatchlistDialogM({ isOpen, onClose }: Props) {
 
   return (
     <BaseDialog
-      className="test"
       fullScreen
       isOpen={isOpen}
       onClose={onClose}

--- a/src/hooks/useZIndex.ts
+++ b/src/hooks/useZIndex.ts
@@ -1,22 +1,6 @@
 import { useEffect, useState } from "react";
 import { create } from "zustand";
 
-export const useZIndex = (isOpen: boolean = true) => {
-  const { pushStack, popStack, getCurrentZIndex } = useZIndexStore();
-
-  const [layoutIndex, setLayoutIndex] = useState(0);
-  const zIndex = getCurrentZIndex(layoutIndex);
-
-  useEffect(() => {
-    const index = pushStack();
-    setLayoutIndex(index);
-
-    return popStack;
-  }, [isOpen, popStack, pushStack]);
-
-  return { zIndex, layoutIndex, pushStack, popStack, getCurrentZIndex };
-};
-
 type ZIndexState = {
   defaultZIndex: number;
   defaultZIndexStep: number;
@@ -26,7 +10,7 @@ type ZIndexState = {
   getCurrentZIndex: (index: number) => number;
 };
 
-const useZIndexStore = create<ZIndexState>((set, get) => ({
+export const useZIndexStore = create<ZIndexState>((set, get) => ({
   defaultZIndex: 1000,
   defaultZIndexStep: 100,
   stackCount: 0,
@@ -43,3 +27,33 @@ const useZIndexStore = create<ZIndexState>((set, get) => ({
     return state.defaultZIndex + state.defaultZIndexStep * index;
   },
 }));
+
+export const useZIndex = (isOpen: boolean = true) => {
+  const pushStack = useZIndexStore((state) => state.pushStack);
+  const popStack = useZIndexStore((state) => state.popStack);
+  const getCurrentZIndex = useZIndexStore((state) => state.getCurrentZIndex);
+
+  const [layoutIndex, setLayoutIndex] = useState(0);
+  const zIndex = getCurrentZIndex(layoutIndex);
+
+  useEffect(() => {
+    if (isOpen) {
+      const index = pushStack();
+      setLayoutIndex(index);
+    }
+
+    return () => {
+      if (isOpen) {
+        popStack();
+      }
+    };
+  }, [isOpen, pushStack, popStack]);
+
+  return {
+    zIndex,
+    layoutIndex,
+    pushStack,
+    popStack,
+    getCurrentZIndex,
+  };
+};


### PR DESCRIPTION
## 구현한 것
- #345 
### 버그 내용
```ts
  useEffect(() => {
    const index = pushStack();
    setLayoutIndex(index);

    return popStack;
  }, [isOpen, popStack, pushStack]);
```
- 첫 랜더링 시 `isOpen` 가 `false` 인 경우 우선 `pushStack()`가 돌면서 index가 증가한다.
- `isOpen`이 true가 되면 레이아웃이 열리고 클린업에서 `popStack()`이 돌면 레이아웃이 열렸지만 index가 줄어든다.
- 그러면서 z-index값이 이상하게 적용되는 경우가 생긴다.

### 수정 후
```ts
  useEffect(() => {
    if (isOpen) {
      const index = pushStack();
      setLayoutIndex(index);
    }

    return () => {
      if (isOpen) {
        popStack();
      }
    };
  }, [isOpen, pushStack, popStack]);
```
- 우선 `isOpen`이 true인 경우만 `pushStack()`을 실행한다. 즉 레이아웃이 열린 경우에만 index를 증가한다.
- 그리고 클린업은 `isOpen`이 true인 경우만 실행하도록 한다.
    - true인 이유는 클린업은 deps인 `isOpen`가 false인 경우(닫혀있는 경우)에 `popStack()`을 하는 경우를 막기 위해
- 이렇게 수정하여 `랜더링`은 되어 있지만 숨겨져 있는 레이아웃은 index 계산을 하지 않고, 활성화 된 레이아웃만 z-index를 계산하게 된다.