### PR TITLE
[refactor] 포트폴리오 페이지 랜더링 최적화

### DIFF
--- a/src/components/Pagination/TablePagination.tsx
+++ b/src/components/Pagination/TablePagination.tsx
@@ -3,6 +3,7 @@ import {
   tablePaginationClasses,
 } from "@mui/material";
 import designSystem from "@styles/designSystem";
+import { memo } from "react";
 import styled from "styled-components";
 import { LabelRowsPerPage } from "./LabelRowsPerPage";
 import Pagination from "./Pagination";
@@ -18,7 +19,7 @@ type Props = {
   onRowsPerPageChange: (value: string) => void;
 };
 
-export default function TablePagination({
+export default memo(function TablePagination({
   count,
   page,
   rowsPerPage,
@@ -63,7 +64,7 @@ export default function TablePagination({
       onPageChange={onPageChange}
     />
   );
-}
+});
 
 const StyledTablePagination = styled(MuiTablePagination)`
   margin-top: 16px;

--- a/src/components/Table/CollapsibleSelectableTable.tsx
+++ b/src/components/Table/CollapsibleSelectableTable.tsx
@@ -9,7 +9,9 @@ import {
   ComponentType,
   MouseEvent,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import TablePagination from "../Pagination/TablePagination";
@@ -109,15 +111,22 @@ export default function CollapsibleSelectableTable<
     [order, orderBy, page, rowsPerPage, tableRows]
   );
 
+  // TODO : 다른 Table component도 고려
+  const visibleRowsRef = useRef(visibleRows);
+
+  useEffect(() => {
+    visibleRowsRef.current = visibleRows;
+  }, [visibleRows]);
+
   const handleSelectAllClick = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (event.target.checked) {
-        setSelected(visibleRows);
-        return;
+        setSelected(visibleRowsRef.current);
+      } else {
+        setSelected([]);
       }
-      setSelected([]);
     },
-    [visibleRows]
+    []
   );
 
   const handleChangeRowsPerPage = useCallback((newValue: string) => {

--- a/src/components/Table/CollapsibleSelectableTable.tsx
+++ b/src/components/Table/CollapsibleSelectableTable.tsx
@@ -4,7 +4,14 @@ import {
   Table as MuiTable,
   TableContainer as MuiTableContainer,
 } from "@mui/material";
-import { ChangeEvent, MouseEvent, useCallback, useMemo, useState } from "react";
+import {
+  ChangeEvent,
+  ComponentType,
+  MouseEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import TablePagination from "../Pagination/TablePagination";
 import { Order } from "./types";
 import { getComparator } from "./utils/comparator";
@@ -14,13 +21,13 @@ type Props<Item> = {
   initialOrderBy: keyof Item;
   rowsPerPageOptions?: number[];
   data: Item[];
-  TableToolBar: (props: {
+  TableToolBar: ComponentType<{
     selected: readonly Item[];
     updateSelected: (newSelected: readonly Item[]) => void;
     isAllDeleteOnLastPage: boolean;
     moveToPrevTablePage: () => void;
-  }) => JSX.Element;
-  TableHead: (props: {
+  }>;
+  TableHead: ComponentType<{
     order: Order;
     orderBy: keyof Item;
     isAllRowsSelectedInCurrentPage: boolean;
@@ -28,15 +35,15 @@ type Props<Item> = {
     onRequestSort: (event: MouseEvent<unknown>, property: keyof Item) => void;
     isAllRowsOpen: boolean;
     onExpandOrCollapseAllRows: (event: MouseEvent) => void;
-  }) => JSX.Element;
-  TableBody: (props: {
+  }>;
+  TableBody: ComponentType<{
     numEmptyRows: number;
     visibleRows: readonly Item[];
     selected: readonly Item[];
     updateSelected: (newSelected: readonly Item[]) => void;
     isAllRowsOpen: boolean;
-  }) => JSX.Element;
-  EmptyTable?: () => JSX.Element;
+  }>;
+  EmptyTable?: ComponentType;
   enableTablePagination?: boolean;
 };
 

--- a/src/components/Table/CollapsibleSelectableTable.tsx
+++ b/src/components/Table/CollapsibleSelectableTable.tsx
@@ -70,23 +70,26 @@ export default function CollapsibleSelectableTable<
   const { state: isAllRowsOpen, setOpposite: handleExpandOrCollapseAllRows } =
     useBoolean();
 
-  const handleRequestSort = (_: MouseEvent<unknown>, property: keyof Item) => {
-    const isAsc = orderBy === property && order === "asc";
-    setOrder(isAsc ? "desc" : "asc");
-    setOrderBy(property);
-  };
+  const handleRequestSort = useCallback(
+    (_: MouseEvent<unknown>, property: keyof Item) => {
+      const isAsc = orderBy === property && order === "asc";
+      setOrder(isAsc ? "desc" : "asc");
+      setOrderBy(property);
+    },
+    []
+  );
 
-  const handleChangePage = (_: unknown, newPage: number) => {
+  const handleChangePage = useCallback((_: unknown, newPage: number) => {
     setPage(newPage);
-  };
+  }, []);
 
-  const moveToPrevTablePage = () => {
+  const moveToPrevTablePage = useCallback(() => {
     setPage((prev) => prev - 1);
-  };
+  }, []);
 
-  const updateSelected = (newSelected: readonly Item[]) => {
+  const updateSelected = useCallback((newSelected: readonly Item[]) => {
     setSelected(newSelected);
-  };
+  }, []);
 
   const numEmptyRows = enableTablePagination
     ? Math.max(0, (1 + page) * Math.min(5, rowsPerPage) - tableRows.length)
@@ -117,10 +120,10 @@ export default function CollapsibleSelectableTable<
     [visibleRows]
   );
 
-  const handleChangeRowsPerPage = (newValue: string) => {
+  const handleChangeRowsPerPage = useCallback((newValue: string) => {
     setRowsPerPage(parseInt(newValue, 10));
     setPage(0);
-  };
+  }, []);
 
   const selectedSet = new Set(selected.map((item) => item.id));
   const isAllRowsSelectedInCurrentPage =
@@ -137,8 +140,8 @@ export default function CollapsibleSelectableTable<
           {TableToolBar && (
             <TableToolBar
               selected={selected}
-              updateSelected={updateSelected}
               isAllDeleteOnLastPage={isAllDeleteOnLastPage}
+              updateSelected={updateSelected}
               moveToPrevTablePage={moveToPrevTablePage}
             />
           )}
@@ -152,17 +155,17 @@ export default function CollapsibleSelectableTable<
                 order={order}
                 orderBy={orderBy}
                 isAllRowsSelectedInCurrentPage={isAllRowsSelectedInCurrentPage}
+                isAllRowsOpen={isAllRowsOpen}
                 onSelectAllClick={handleSelectAllClick}
                 onRequestSort={handleRequestSort}
-                isAllRowsOpen={isAllRowsOpen}
                 onExpandOrCollapseAllRows={handleExpandOrCollapseAllRows}
               />
               <TableBody
                 numEmptyRows={numEmptyRows}
                 visibleRows={visibleRows}
                 selected={selected}
-                updateSelected={updateSelected}
                 isAllRowsOpen={isAllRowsOpen}
+                updateSelected={updateSelected}
               />
             </MuiTable>
           </MuiTableContainer>

--- a/src/features/portfolio/components/Portfolio/desktop/MainPanelD.tsx
+++ b/src/features/portfolio/components/Portfolio/desktop/MainPanelD.tsx
@@ -4,6 +4,7 @@ import {
 } from "@features/portfolio/api/types";
 import { Box } from "@mui/material";
 import designSystem from "@styles/designSystem";
+import { memo } from "react";
 import styled from "styled-components";
 import EmptyPortfolioHoldingTable from "../../PortfolioHolding/EmptyPortfolioHoldingTable";
 import PortfolioHoldingTable from "../../PortfolioHolding/desktop/PortfolioHoldingTable";
@@ -15,7 +16,7 @@ type Props = {
   hasNoHoldings: boolean;
 };
 
-export default function MainPanelD({
+export default memo(function MainPanelD({
   freshPortfolioDetailsData,
   freshPortfolioHoldingsData,
   hasNoHoldings,
@@ -35,7 +36,7 @@ export default function MainPanelD({
       )}
     </StyledMainPanel>
   );
-}
+});
 
 const StyledMainPanel = styled.div`
   width: 960px;

--- a/src/features/portfolio/components/Portfolio/desktop/MainPanelD.tsx
+++ b/src/features/portfolio/components/Portfolio/desktop/MainPanelD.tsx
@@ -23,9 +23,7 @@ export default memo(function MainPanelD({
 }: Props) {
   return (
     <StyledMainPanel>
-      <PortfolioOverviewContainer>
-        <PortfolioOverviewD data={freshPortfolioDetailsData} />
-      </PortfolioOverviewContainer>
+      <PortfolioOverviewD data={freshPortfolioDetailsData} />
 
       {hasNoHoldings ? (
         <EmptyPortfolioHoldingTable />
@@ -46,10 +44,6 @@ const StyledMainPanel = styled.div`
   padding: 32px;
   background-color: ${designSystem.color.neutral.white};
   border-radius: 8px;
-`;
-
-const PortfolioOverviewContainer = styled.div`
-  width: 100%;
 `;
 
 const PortfolioHoldingsContainer = styled(Box)`

--- a/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingRow.tsx
+++ b/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingRow.tsx
@@ -121,8 +121,6 @@ function PortfolioHoldingRow({
   );
 }
 
-// 이후에 필요한 다른 memoized 컴포넌트들 정의
-
 const MemoizedHoldingTableCell = memo(
   ({
     isRowOpen,

--- a/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingRow.tsx
+++ b/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingRow.tsx
@@ -8,25 +8,26 @@ import { thousandsDelimiter } from "@fineants/demolition";
 import { Collapse, TableCell, TableRow, Typography } from "@mui/material";
 import Routes from "@router/Routes";
 import designSystem from "@styles/designSystem";
-import { MouseEvent, useEffect, useState } from "react";
+import { MouseEvent, memo, useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import styled from "styled-components";
 import PortfolioHoldingLotsTableD from "./PortfolioHoldingLots/PortfolioHoldingLotsTableD";
 
 type Props = {
   labelId: string;
-  row: PortfolioHolding;
   isItemSelected: boolean;
   isAllRowsOpen: boolean;
-  handleClick: (event: MouseEvent<unknown>, id: number) => void;
-};
+  handleClick: (event: MouseEvent<unknown>, row: PortfolioHolding) => void;
+} & PortfolioHolding;
 
-export default function PortfolioHoldingRow({
+export default memo(PortfolioHoldingRow);
+
+function PortfolioHoldingRow({
   labelId,
-  row,
   isItemSelected,
   isAllRowsOpen,
   handleClick,
+  ...row
 }: Props) {
   const { portfolioId } = useParams();
 
@@ -49,12 +50,13 @@ export default function PortfolioHoldingRow({
 
   const [isRowOpen, setIsRowOpen] = useState(false);
 
-  const onExpandRowClick = (
-    event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>
-  ) => {
-    event.stopPropagation();
-    setIsRowOpen(!isRowOpen);
-  };
+  const onExpandRowClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>) => {
+      event.stopPropagation();
+      setIsRowOpen((prev) => !prev);
+    },
+    []
+  );
 
   // TODO: Reduce rendering (currently renders twice)
   useEffect(() => {
@@ -66,112 +68,42 @@ export default function PortfolioHoldingRow({
       <StyledHoldingTableRow
         tabIndex={-1}
         selected={isItemSelected}
-        onClick={(event) => handleClick(event, id)}
+        onClick={(event) => handleClick(event, row)}
         aria-selected={isItemSelected}>
-        <HoldingTableCell
-          style={{
-            width: "40px",
-            padding: "0 8px 0 16px",
-          }}>
-          <IconButton
-            icon={isRowOpen ? "chevron-down" : "chevron-right"}
-            size="h24"
-            iconColor="custom"
-            customColor={{
-              color: "gray400",
-              hoverColor: "gray200",
-            }}
-            onClick={(event) => onExpandRowClick(event)}
-            aria-label="포트폴리오 종목 펼치기 버튼"
-          />
-        </HoldingTableCell>
+        <MemoizedHoldingTableCell
+          isRowOpen={isRowOpen}
+          onExpandRowClick={onExpandRowClick}
+        />
 
-        <HoldingTableCell style={{ width: "32px", padding: "0" }}>
-          <CheckBox
-            size="h16"
-            checkType="check"
-            checked={isItemSelected}
-            aria-checked={isItemSelected}
-            inputProps={{
-              "aria-label": labelId,
-            }}
-          />
-        </HoldingTableCell>
+        <MemoizedCheckBoxCell
+          isItemSelected={isItemSelected}
+          labelId={labelId}
+        />
 
-        <HoldingTableCell style={{ width: "132px" }}>
-          <Typography sx={{ fontSize: "1rem" }} component="h3">
-            <Link
-              style={{ font: designSystem.font.body3.font }}
-              to={Routes.STOCK(tickerSymbol)}>
-              <EllipsisTextTooltip defaultMaxWidth="116px">
-                {companyName}
-              </EllipsisTextTooltip>
-            </Link>
-          </Typography>
-          <Typography
-            style={{
-              font: designSystem.font.body4.font,
-              color: designSystem.color.neutral.gray400,
-            }}>
-            {tickerSymbol}
-          </Typography>
-        </HoldingTableCell>
+        <MemoizedCompanyInfoCell
+          companyName={companyName}
+          tickerSymbol={tickerSymbol}
+        />
 
-        <HoldingTableCell style={{ width: "108px" }} align="right">
-          <RealtimeValue value={currentValuation} />
-        </HoldingTableCell>
-
-        <HoldingTableCell style={{ width: "108px" }} align="right">
-          <RealtimeValue value={currentPrice} />
-        </HoldingTableCell>
-
-        <HoldingTableCell style={{ width: "108px" }} align="right">
-          <Amount>{thousandsDelimiter(averageCostPerShare)}</Amount>
-        </HoldingTableCell>
-
-        <HoldingTableCell style={{ width: "64px" }} align="right">
-          <HoldingTypography>{numShares}</HoldingTypography>
-        </HoldingTableCell>
-
-        <HoldingTableCell style={{ width: "80px" }} align="right">
-          <RealtimeValue value={dailyChange} />
-          <div>
-            <RateBadge
-              size={12}
-              value={dailyChangeRate}
-              bgColorStatus={false}
-            />
-          </div>
-        </HoldingTableCell>
-
-        <HoldingTableCell style={{ width: "108px" }} align="right">
-          <RealtimeValue value={totalGain} />
-          <div>
-            <RateBadge
-              size={12}
-              value={totalReturnRate}
-              bgColorStatus={false}
-            />
-          </div>
-        </HoldingTableCell>
-
-        <HoldingTableCell
-          style={{
-            width: "116px",
-            padding: "0 16px 0 8px",
-          }}
-          align="right">
-          <HoldingTypography>
-            {thousandsDelimiter(annualDividend)}
-          </HoldingTypography>
-          <div>
-            <RateBadge
-              size={12}
-              value={annualDividendYield}
-              bgColorStatus={false}
-            />
-          </div>
-        </HoldingTableCell>
+        <MemoizedTableCell value={currentValuation} width="108px" />
+        <MemoizedTableCell value={currentPrice} width="108px" />
+        <MemoizedAmountCell value={averageCostPerShare} width="108px" />
+        <MemoizedTextCell text={numShares} width="64px" />
+        <MemoizedTableCellWithRateBadge
+          value={dailyChange}
+          rate={dailyChangeRate}
+          width="80px"
+        />
+        <MemoizedTableCellWithRateBadge
+          value={totalGain}
+          rate={totalReturnRate}
+          width="108px"
+        />
+        <MemoizedTableCellWithRateBadge
+          value={annualDividend}
+          rate={annualDividendYield}
+          width="116px"
+        />
       </StyledHoldingTableRow>
 
       <StyledHoldingLotRow>
@@ -188,6 +120,131 @@ export default function PortfolioHoldingRow({
     </>
   );
 }
+
+// 이후에 필요한 다른 memoized 컴포넌트들 정의
+
+const MemoizedHoldingTableCell = memo(
+  ({
+    isRowOpen,
+    onExpandRowClick,
+  }: {
+    isRowOpen: boolean;
+    onExpandRowClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  }) => (
+    <HoldingTableCell
+      style={{
+        width: "40px",
+        padding: "0 8px 0 16px",
+      }}>
+      <IconButton
+        icon={isRowOpen ? "chevron-down" : "chevron-right"}
+        size="h24"
+        iconColor="custom"
+        customColor={{
+          color: "gray400",
+          hoverColor: "gray200",
+        }}
+        onClick={onExpandRowClick}
+        aria-label="포트폴리오 종목 펼치기 버튼"
+      />
+    </HoldingTableCell>
+  )
+);
+
+const MemoizedCheckBoxCell = memo(
+  ({
+    isItemSelected,
+    labelId,
+  }: {
+    isItemSelected: boolean;
+    labelId: string;
+  }) => (
+    <HoldingTableCell style={{ width: "32px", padding: "0" }}>
+      <CheckBox
+        size="h16"
+        checkType="check"
+        checked={isItemSelected}
+        aria-checked={isItemSelected}
+        inputProps={{
+          "aria-label": labelId,
+        }}
+      />
+    </HoldingTableCell>
+  )
+);
+
+const MemoizedCompanyInfoCell = memo(
+  ({
+    companyName,
+    tickerSymbol,
+  }: {
+    companyName: string;
+    tickerSymbol: string;
+  }) => (
+    <HoldingTableCell style={{ width: "132px" }}>
+      <Typography sx={{ fontSize: "1rem" }} component="h3">
+        <Link
+          style={{ font: designSystem.font.body3.font }}
+          to={Routes.STOCK(tickerSymbol)}>
+          <EllipsisTextTooltip defaultMaxWidth="116px">
+            {companyName}
+          </EllipsisTextTooltip>
+        </Link>
+      </Typography>
+
+      <Typography
+        style={{
+          font: designSystem.font.body4.font,
+          color: designSystem.color.neutral.gray400,
+        }}>
+        {tickerSymbol}
+      </Typography>
+    </HoldingTableCell>
+  )
+);
+
+const MemoizedTableCell = memo(
+  ({
+    value,
+    width,
+    align = "right",
+  }: {
+    value: number;
+    width: string;
+    align?: "left" | "right";
+  }) => (
+    <HoldingTableCell style={{ width }} align={align}>
+      <RealtimeValue value={value} />
+    </HoldingTableCell>
+  )
+);
+
+const MemoizedTableCellWithRateBadge = memo(
+  ({ value, rate, width }: { value: number; rate: number; width: string }) => (
+    <HoldingTableCell style={{ width }} align="right">
+      <RealtimeValue value={value} />
+      <div>
+        <RateBadge size={12} value={rate} bgColorStatus={false} />
+      </div>
+    </HoldingTableCell>
+  )
+);
+
+const MemoizedAmountCell = memo(
+  ({ value, width }: { value: number; width: string }) => (
+    <HoldingTableCell style={{ width }} align="right">
+      <Amount>{thousandsDelimiter(value)}</Amount>
+    </HoldingTableCell>
+  )
+);
+
+const MemoizedTextCell = memo(
+  ({ text, width }: { text: number; width: string }) => (
+    <HoldingTableCell style={{ width }} align="right">
+      <HoldingTypography>{text}</HoldingTypography>
+    </HoldingTableCell>
+  )
+);
 
 const StyledHoldingTableRow = styled(TableRow)`
   &.Mui-selected {

--- a/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingTableBody.tsx
+++ b/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingTableBody.tsx
@@ -1,49 +1,48 @@
 import { PortfolioHolding } from "@features/portfolio/api/types";
 import { TableBody, TableCell, TableRow } from "@mui/material";
-import { MouseEvent } from "react";
+import { MouseEvent, memo, useCallback } from "react";
 import PortfolioHoldingRow from "./PortfolioHoldingRow";
 
 type Props = {
   numEmptyRows: number;
   visibleRows: readonly PortfolioHolding[];
   selected: readonly PortfolioHolding[];
-  updateSelected: (selected: readonly PortfolioHolding[]) => void;
   isAllRowsOpen: boolean;
+  updateSelected: (selected: readonly PortfolioHolding[]) => void;
 };
 
-export default function PortfolioHoldingTableBody({
+export default memo(function PortfolioHoldingTableBody({
   numEmptyRows,
   visibleRows,
   selected,
-  updateSelected,
   isAllRowsOpen,
+  updateSelected,
 }: Props) {
-  const handleClick = (_: MouseEvent<unknown>, id: number) => {
-    const selectedItem = selected.find((item) => item.id === id);
-    const selectedItemIndex = selectedItem
-      ? selected.indexOf(selectedItem)
-      : -1;
-
-    let newSelected: readonly PortfolioHolding[] = [];
-
-    if (selectedItemIndex === -1) {
-      // 선택이 되어있지 않은 경우, 해당 아이템을 선택 및 추가
-      const targetItem = visibleRows.find((item) => item.id === id);
-      newSelected = newSelected.concat(selected, targetItem ?? []);
-    } else if (selectedItemIndex === 0) {
-      newSelected = newSelected.concat(selected.slice(1));
-    } else if (selectedItemIndex === selected.length - 1) {
-      newSelected = newSelected.concat(selected.slice(0, -1));
-    } else if (selectedItemIndex > 0) {
-      newSelected = newSelected.concat(
-        selected.slice(0, selectedItemIndex),
-        selected.slice(selectedItemIndex + 1)
+  // TODO 다른 TableBody도 다음과같이 수정하기
+  const handleClick = useCallback(
+    (_: MouseEvent<unknown>, row: PortfolioHolding) => {
+      const selectedItemIndex = selected.findIndex(
+        (item) => item.id === row.id
       );
-    }
-    updateSelected(newSelected);
-  };
+      let newSelected: readonly PortfolioHolding[] = [];
 
-  const isSelected = (id: number) => !!selected.find((item) => item.id === id);
+      if (selectedItemIndex === -1) {
+        newSelected = [...selected, row];
+      } else {
+        newSelected = selected.filter(
+          (_, index) => index !== selectedItemIndex
+        );
+      }
+
+      updateSelected(newSelected);
+    },
+    [selected, updateSelected]
+  );
+
+  const isSelected = useCallback(
+    (id: number) => !!selected.find((item) => item.id === id),
+    [selected]
+  );
 
   return (
     <TableBody>
@@ -59,10 +58,10 @@ export default function PortfolioHoldingTableBody({
           <PortfolioHoldingRow
             key={row.id}
             labelId={labelId}
-            row={row}
             isItemSelected={isItemSelected}
             isAllRowsOpen={isAllRowsOpen}
             handleClick={handleClick}
+            {...row}
           />
         );
       })}
@@ -76,4 +75,4 @@ export default function PortfolioHoldingTableBody({
       )}
     </TableBody>
   );
-}
+});

--- a/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingTableHead.tsx
+++ b/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingTableHead.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { visuallyHidden } from "@mui/utils";
 import designSystem from "@styles/designSystem";
-import { ChangeEvent, MouseEvent } from "react";
+import { ChangeEvent, MouseEvent, memo } from "react";
 import styled from "styled-components";
 
 type Props = {
@@ -87,7 +87,7 @@ const headCells: readonly HeadCell[] = [
   },
 ];
 
-export default function PortfolioHoldingTableHead({
+export default memo(function PortfolioHoldingTableHead({
   order,
   orderBy,
   isAllRowsSelectedInCurrentPage,
@@ -188,7 +188,7 @@ export default function PortfolioHoldingTableHead({
       </StyledTableRow>
     </StyledTableHead>
   );
-}
+});
 
 const StyledTableHead = styled(TableHead)`
   height: 48px;

--- a/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingTableToolBar.tsx
+++ b/src/features/portfolio/components/PortfolioHolding/desktop/PortfolioHoldingTableToolBar.tsx
@@ -5,6 +5,7 @@ import { PortfolioHolding } from "@features/portfolio/api/types";
 import { useBoolean } from "@fineants/demolition";
 import { Toolbar, Typography } from "@mui/material";
 import designSystem from "@styles/designSystem";
+import { memo } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import PortfolioHoldingAddDialog from "../PortfolioHoldingAddDialog";
@@ -12,15 +13,15 @@ import PortfolioHoldingSelectedDeleteConfirm from "../PortfolioHoldingSelectedDe
 
 type Props = {
   selected: readonly PortfolioHolding[];
-  updateSelected: (newSelected: readonly PortfolioHolding[]) => void;
   isAllDeleteOnLastPage: boolean;
+  updateSelected: (newSelected: readonly PortfolioHolding[]) => void;
   moveToPrevTablePage: () => void;
 };
 
-export default function PortfolioHoldingTableToolBar({
+export default memo(function PortfolioHoldingTableToolBar({
   selected,
-  updateSelected,
   isAllDeleteOnLastPage,
+  updateSelected,
   moveToPrevTablePage,
 }: Props) {
   const { portfolioId } = useParams();
@@ -100,7 +101,7 @@ export default function PortfolioHoldingTableToolBar({
       />
     </StyledToolbar>
   );
-}
+});
 
 const StyledToolbar = styled(Toolbar)`
   height: 32px;

--- a/src/features/portfolio/components/PortfolioOverview/TargetGainToolTip.tsx
+++ b/src/features/portfolio/components/PortfolioOverview/TargetGainToolTip.tsx
@@ -1,0 +1,38 @@
+import { IconButton } from "@components/Buttons/IconButton";
+import ConditionalTooltip from "@components/Tooltips/ConditionalTooltip";
+
+type Props = {
+  targetGain: number;
+  targetGainNotify: boolean;
+  disabled: boolean;
+  onClick: () => void;
+};
+
+export function TargetGainToolTip({
+  targetGain,
+  targetGainNotify,
+  disabled,
+  onClick,
+}: Props) {
+  return (
+    <ConditionalTooltip
+      condition={targetGain !== 0}
+      title={"포트폴리오 목표 수익률을 먼저 설정해주세요"}
+      placement={"bottom-start"}>
+      <div>
+        <IconButton
+          icon="notification"
+          size="h24"
+          iconColor="custom"
+          customColor={{
+            color: targetGainNotify ? "blue500" : "gray400",
+            hoverColor: "gray50",
+          }}
+          disabled={disabled}
+          onClick={onClick}
+          aria-label="목표 수익률 알림 설정 토글"
+        />
+      </div>
+    </ConditionalTooltip>
+  );
+}

--- a/src/features/portfolio/components/PortfolioOverview/desktop/PortfolioOverviewBodyD.tsx
+++ b/src/features/portfolio/components/PortfolioOverview/desktop/PortfolioOverviewBodyD.tsx
@@ -9,14 +9,19 @@ import RealtimeValue from "@features/portfolio/components/RealtimeValue";
 import { thousandsDelimiter } from "@fineants/demolition";
 import { debounce } from "@mui/material";
 import designSystem from "@styles/designSystem";
+import { memo, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
+import { TargetGainToolTip } from "../TargetGainToolTip";
 
 type Props = {
-  data: PortfolioDetails;
+  data: Omit<
+    PortfolioDetails,
+    "id" | "name" | "securitiesFirm" | "currentValuation"
+  >;
 };
 
-export default function PortfolioOverviewBodyD({ data }: Props) {
+export default memo(function PortfolioOverviewBodyD({ data }: Props) {
   const {
     budget,
     investedAmount,
@@ -38,228 +43,303 @@ export default function PortfolioOverviewBodyD({ data }: Props) {
   } = data;
 
   const { portfolioId } = useParams();
-
   const { mutate } = usePortfolioNotificationSettingsMutation(
     Number(portfolioId)
   );
 
-  const onTargetGainNotifyButtonClick = debounce(() => {
-    mutate({
-      notificationType: "targetGain",
-      body: { isActive: !targetGainNotify },
-    });
-  }, 250);
+  const onTargetGainNotifyButtonClick = useCallback(
+    debounce(() => {
+      mutate({
+        notificationType: "targetGain",
+        body: { isActive: !targetGainNotify },
+      });
+    }, 250),
+    []
+  );
 
-  const onMaxLossNotifyButtonClick = debounce(() => {
-    mutate({
-      notificationType: "maxLoss",
-      body: { isActive: !maxLossNotify },
-    });
-  }, 250);
+  const onMaxLossNotifyButtonClick = useCallback(
+    debounce(() => {
+      mutate({
+        notificationType: "maxLoss",
+        body: { isActive: !maxLossNotify },
+      });
+    }, 250),
+    []
+  );
 
   return (
     <StyledOverviewBody>
-      <OverviewBodyTop>
-        <OverviewBodySection>
-          <OverviewBodyData>
-            <div>예산</div>
-            <span>{thousandsDelimiter(budget)}</span>
-          </OverviewBodyData>
-          <OverviewBodyData>
-            <div>투자금액</div>
-            <span>{thousandsDelimiter(investedAmount)}</span>
-          </OverviewBodyData>
-          <OverviewBodyData>
-            <div>잔고</div>
-            <span>{thousandsDelimiter(balance)}</span>
-          </OverviewBodyData>
-          <OverviewBodyData>
-            <CustomTooltip
-              placement="bottom-start"
-              title={
-                <p>
-                  손실 종목을 매도 시 현재 잔고의 감당력을 표현하는 것으로 매도
-                  후 실제 잔고를 나타내는 것이 아닙니다
-                  <br />
-                  잔고 - 손실 종목의 손실 합
-                </p>
-              }>
-              <div
-                style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                잠정 손실 잔고 <Icon icon="help" size={16} color="gray400" />
-              </div>
-            </CustomTooltip>
-            <span>{thousandsDelimiter(provisionalLossBalance)}</span>
-          </OverviewBodyData>
-        </OverviewBodySection>
-        <OverviewBodySection>
-          <OverviewBodyData>
-            <NotificationLabel>
-              목표 수익률
-              <ConditionalTooltip
-                condition={targetGain !== 0}
-                title={"포트폴리오 목표 수익률을 먼저 설정해주세요"}
-                placement={"bottom-start"}>
-                <div>
-                  <IconButton
-                    icon="notification"
-                    size="h24"
-                    iconColor="custom"
-                    customColor={{
-                      color: targetGainNotify ? "blue500" : "gray400",
-                      hoverColor: "gray50",
-                    }}
-                    disabled={targetGain === 0}
-                    onClick={onTargetGainNotifyButtonClick}
-                    aria-label="목표 수익률 알림 설정 토글"
-                  />
-                </div>
-              </ConditionalTooltip>
-            </NotificationLabel>
-            <span>
-              {targetGain === 0 ? "-" : thousandsDelimiter(targetGain)}
-            </span>
-          </OverviewBodyData>
-          <div style={{ marginLeft: "auto" }}>
-            {targetGain === 0 ? (
-              "-"
-            ) : (
-              <RateBadge
-                size={16}
-                value={targetReturnRate}
-                bgColorStatus={false}
-                iconStatus={false}
-              />
-            )}
-          </div>
-          <OverviewBodyData>
-            <NotificationLabel>
-              최대 손실률
-              <ConditionalTooltip
-                condition={maximumLoss !== 0}
-                title={"포트폴리오 최대 손실률을 먼저 설정해주세요"}
-                placement={"bottom-start"}>
-                <div>
-                  <IconButton
-                    icon="notification"
-                    size="h24"
-                    iconColor="custom"
-                    customColor={{
-                      color: maxLossNotify ? "blue500" : "gray400",
-                      hoverColor: "gray50",
-                    }}
-                    disabled={maximumLoss === 0}
-                    onClick={onMaxLossNotifyButtonClick}
-                    aria-label="최대 손실률 알림 설정 토글"
-                  />
-                </div>
-              </ConditionalTooltip>
-            </NotificationLabel>
-            <span>
-              {maximumLoss === 0 ? "-" : thousandsDelimiter(maximumLoss)}
-            </span>
-          </OverviewBodyData>
-          <div style={{ marginLeft: "auto" }}>
-            {maximumLoss === 0 ? (
-              "-"
-            ) : (
-              <RateBadge
-                size={16}
-                value={-maximumLossRate}
-                bgColorStatus={false}
-                iconStatus={false}
-              />
-            )}
-          </div>
-        </OverviewBodySection>
-      </OverviewBodyTop>
-
-      <OverviewBodyBottom>
-        <OverviewBodySection>
-          <OverviewBodyData>
-            <div>총 손익</div>
-            <RealtimeValue value={totalGain} />
-          </OverviewBodyData>
-          <div style={{ marginLeft: "auto" }}>
-            <RateBadge
-              size={16}
-              value={totalGainRate}
-              bgColorStatus={false}
-              iconStatus={false}
-            />
-          </div>
-          <OverviewBodyData>
-            <div>당일 손익</div>
-            <RealtimeValue value={dailyGain} />
-          </OverviewBodyData>
-          <div style={{ marginLeft: "auto" }}>
-            <RateBadge
-              size={16}
-              value={dailyGainRate}
-              bgColorStatus={false}
-              iconStatus={false}
-            />
-          </div>
-        </OverviewBodySection>
-        <OverviewBodySection>
-          <OverviewBodyData>
-            <div>총 연배당금</div>
-            <span>{thousandsDelimiter(annualDividend)}</span>
-          </OverviewBodyData>
-          <div style={{ marginLeft: "auto" }}>
-            <RateBadge
-              size={16}
-              value={annualDividendYield}
-              bgColorStatus={false}
-              iconStatus={false}
-            />
-          </div>
-          <OverviewBodyData>
-            <CustomTooltip
-              placement="bottom-start"
-              title={
-                <p style={{ font: designSystem.font.body4.font }}>
-                  총 투자금액 대비 연배당률
-                  <br />연 배당금 / 투자금액 * 100%
-                </p>
-              }>
-              <div
-                style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                투자대비 연 배당률
-                <Icon icon="help" size={16} color="gray400" />
-              </div>
-            </CustomTooltip>
-            <RateBadge
-              size={16}
-              value={annualInvestmentDividendYield}
-              bgColorStatus={false}
-              iconStatus={false}
-            />
-          </OverviewBodyData>
-        </OverviewBodySection>
-      </OverviewBodyBottom>
+      <BudgetSection
+        budget={budget}
+        investedAmount={investedAmount}
+        balance={balance}
+        provisionalLossBalance={provisionalLossBalance}
+      />
+      <TargetAndLossSection
+        targetGain={targetGain}
+        targetReturnRate={targetReturnRate}
+        targetGainNotify={targetGainNotify}
+        maximumLoss={maximumLoss}
+        maximumLossRate={maximumLossRate}
+        maxLossNotify={maxLossNotify}
+        onTargetGainNotifyButtonClick={onTargetGainNotifyButtonClick}
+        onMaxLossNotifyButtonClick={onMaxLossNotifyButtonClick}
+      />
+      <GainAndLossSection
+        totalGain={totalGain}
+        totalGainRate={totalGainRate}
+        dailyGain={dailyGain}
+        dailyGainRate={dailyGainRate}
+      />
+      <DividendSection
+        annualDividend={annualDividend}
+        annualDividendYield={annualDividendYield}
+        annualInvestmentDividendYield={annualInvestmentDividendYield}
+      />
     </StyledOverviewBody>
   );
-}
+});
+
+const BudgetSection = memo(function ({
+  budget,
+  investedAmount,
+  balance,
+  provisionalLossBalance,
+}: Pick<
+  PortfolioDetails,
+  "budget" | "investedAmount" | "balance" | "provisionalLossBalance"
+>) {
+  return (
+    <OverviewBodySection>
+      <OverviewBodyData>
+        <div>예산</div>
+        <span>{thousandsDelimiter(budget)}</span>
+      </OverviewBodyData>
+      <OverviewBodyData>
+        <div>투자금액</div>
+        <span>{thousandsDelimiter(investedAmount)}</span>
+      </OverviewBodyData>
+      <OverviewBodyData>
+        <div>잔고</div>
+        <span>{thousandsDelimiter(balance)}</span>
+      </OverviewBodyData>
+      <OverviewBodyData>
+        <CustomTooltip
+          placement="bottom-start"
+          title={
+            <p>
+              손실 종목을 매도 시 현재 잔고의 감당력을 표현하는 것으로 매도 후
+              실제 잔고를 나타내는 것이 아닙니다
+              <br />
+              잔고 - 손실 종목의 손실 합
+            </p>
+          }>
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            잠정 손실 잔고 <Icon icon="help" size={16} color="gray400" />
+          </div>
+        </CustomTooltip>
+        <span>{thousandsDelimiter(provisionalLossBalance)}</span>
+      </OverviewBodyData>
+    </OverviewBodySection>
+  );
+});
+
+const TargetAndLossSection = memo(function ({
+  targetGain,
+  targetReturnRate,
+  targetGainNotify,
+  maximumLoss,
+  maximumLossRate,
+  maxLossNotify,
+  onTargetGainNotifyButtonClick,
+  onMaxLossNotifyButtonClick,
+}: Pick<
+  PortfolioDetails,
+  | "targetGain"
+  | "targetReturnRate"
+  | "targetGainNotify"
+  | "maximumLoss"
+  | "maximumLossRate"
+  | "maxLossNotify"
+> & {
+  onTargetGainNotifyButtonClick: () => void;
+  onMaxLossNotifyButtonClick: () => void;
+}) {
+  return (
+    <OverviewBodySection>
+      <OverviewBodyData>
+        <NotificationLabel>
+          목표 수익률
+          <TargetGainToolTip
+            targetGain={targetGain}
+            targetGainNotify={targetGainNotify}
+            disabled={targetGain === 0}
+            onClick={onTargetGainNotifyButtonClick}
+          />
+        </NotificationLabel>
+        <span>{targetGain === 0 ? "-" : thousandsDelimiter(targetGain)}</span>
+      </OverviewBodyData>
+      <div style={{ marginLeft: "auto" }}>
+        {targetGain === 0 ? (
+          "-"
+        ) : (
+          <RateBadge
+            size={16}
+            value={targetReturnRate}
+            bgColorStatus={false}
+            iconStatus={false}
+          />
+        )}
+      </div>
+      <OverviewBodyData>
+        <NotificationLabel>
+          최대 손실률
+          <ConditionalTooltip
+            condition={maximumLoss !== 0}
+            title={"포트폴리오 최대 손실률을 먼저 설정해주세요"}
+            placement={"bottom-start"}>
+            <div>
+              <IconButton
+                icon="notification"
+                size="h24"
+                iconColor="custom"
+                customColor={{
+                  color: maxLossNotify ? "blue500" : "gray400",
+                  hoverColor: "gray50",
+                }}
+                disabled={maximumLoss === 0}
+                onClick={onMaxLossNotifyButtonClick}
+                aria-label="최대 손실률 알림 설정 토글"
+              />
+            </div>
+          </ConditionalTooltip>
+        </NotificationLabel>
+        <span>{maximumLoss === 0 ? "-" : thousandsDelimiter(maximumLoss)}</span>
+      </OverviewBodyData>
+      <div style={{ marginLeft: "auto" }}>
+        {maximumLoss === 0 ? (
+          "-"
+        ) : (
+          <RateBadge
+            size={16}
+            value={-maximumLossRate}
+            bgColorStatus={false}
+            iconStatus={false}
+          />
+        )}
+      </div>
+    </OverviewBodySection>
+  );
+});
+
+const GainAndLossSection = memo(function ({
+  totalGain,
+  totalGainRate,
+  dailyGain,
+  dailyGainRate,
+}: Pick<
+  PortfolioDetails,
+  "totalGain" | "totalGainRate" | "dailyGain" | "dailyGainRate"
+>) {
+  return (
+    <OverviewBodySection>
+      <OverviewBodyData>
+        <div>총 손익</div>
+        <RealtimeValue value={totalGain} />
+      </OverviewBodyData>
+      <div style={{ marginLeft: "auto" }}>
+        <RateBadge
+          size={16}
+          value={totalGainRate}
+          bgColorStatus={false}
+          iconStatus={false}
+        />
+      </div>
+      <OverviewBodyData>
+        <div>당일 손익</div>
+        <RealtimeValue value={dailyGain} />
+      </OverviewBodyData>
+      <div style={{ marginLeft: "auto" }}>
+        <RateBadge
+          size={16}
+          value={dailyGainRate}
+          bgColorStatus={false}
+          iconStatus={false}
+        />
+      </div>
+    </OverviewBodySection>
+  );
+});
+
+const DividendSection = memo(function ({
+  annualDividend,
+  annualDividendYield,
+  annualInvestmentDividendYield,
+}: Pick<
+  PortfolioDetails,
+  "annualDividend" | "annualDividendYield" | "annualInvestmentDividendYield"
+>) {
+  return (
+    <OverviewBodySection>
+      <OverviewBodyData>
+        <div>총 연배당금</div>
+        <span>{thousandsDelimiter(annualDividend)}</span>
+      </OverviewBodyData>
+      <div style={{ marginLeft: "auto" }}>
+        <RateBadge
+          size={16}
+          value={annualDividendYield}
+          bgColorStatus={false}
+          iconStatus={false}
+        />
+      </div>
+      <OverviewBodyData>
+        <CustomTooltip
+          placement="bottom-start"
+          title={
+            <p style={{ font: designSystem.font.body4.font }}>
+              총 투자금액 대비 연배당률
+              <br />연 배당금 / 투자금액 * 100%
+            </p>
+          }>
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            투자대비 연 배당률
+            <Icon icon="help" size={16} color="gray400" />
+          </div>
+        </CustomTooltip>
+        <RateBadge
+          size={16}
+          value={annualInvestmentDividendYield}
+          bgColorStatus={false}
+          iconStatus={false}
+        />
+      </OverviewBodyData>
+    </OverviewBodySection>
+  );
+});
 
 const StyledOverviewBody = styled.div`
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 1px;
   border: 1px solid ${designSystem.color.neutral.gray100};
   border-radius: 8px;
-  font: ${designSystem.font.title5.font};
-  letter-spacing: ${designSystem.font.title5.letterSpacing};
-  color: ${designSystem.color.neutral.gray600};
   overflow: hidden;
-`;
 
-const OverviewBodyTop = styled.div`
-  display: flex;
-  border-bottom: 1px solid ${designSystem.color.neutral.gray100};
-`;
+  & > div {
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+  }
 
-const OverviewBodyBottom = styled.div`
-  display: flex;
+  & > div:nth-child(odd) {
+    border-right: 1px solid ${designSystem.color.neutral.gray100};
+  }
+
+  & > div:nth-child(-n + 2) {
+    border-bottom: 1px solid ${designSystem.color.neutral.gray100};
+  }
 `;
 
 const OverviewBodySection = styled.div`

--- a/src/features/portfolio/components/PortfolioOverview/desktop/PortfolioOverviewD.tsx
+++ b/src/features/portfolio/components/PortfolioOverview/desktop/PortfolioOverviewD.tsx
@@ -9,7 +9,7 @@ import PortfolioEditDialog from "@features/portfolio/components/PortfolioAddOrEd
 import { thousandsDelimiter, useBoolean } from "@fineants/demolition";
 import Routes from "@router/Routes";
 import designSystem from "@styles/designSystem";
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import PortfolioDeleteConfirm from "../../PortfolioDeleteConfirm";
@@ -25,10 +25,6 @@ export default memo(function PortfolioOverviewD({ data }: Props) {
   const { mutate: portfolioDeleteMutate } = usePortfolioDeleteMutation();
 
   const { id, name, securitiesFirm, currentValuation, ...overViewData } = data;
-  const memoizedOverViewData = useMemo(
-    () => overViewData,
-    [id, name, securitiesFirm, currentValuation]
-  );
 
   const {
     state: isDialogOpen,
@@ -58,7 +54,7 @@ export default memo(function PortfolioOverviewD({ data }: Props) {
 
       <CurrentValue currentValuation={currentValuation} />
 
-      <PortfolioOverviewBodyD data={memoizedOverViewData} />
+      <PortfolioOverviewBodyD data={overViewData} />
 
       {isDialogOpen && (
         <PortfolioEditDialog

--- a/src/features/portfolio/components/PortfolioOverview/desktop/PortfolioOverviewD.tsx
+++ b/src/features/portfolio/components/PortfolioOverview/desktop/PortfolioOverviewD.tsx
@@ -91,7 +91,7 @@ const Header = memo(function ({
     <PortfolioOverviewHead>
       <Breadcrumb
         depthData={[
-          { name: "내 포트폴리오", url: "/portfolios" },
+          { name: "내 포트폴리오", url: Routes.PORTFOLIOS },
           { name, url: Routes.PORTFOLIO(id) },
         ]}
       />


### PR DESCRIPTION
## 구현한 것
- #363 
- **데스크탑 기준 리팩터링 진행**
- 주식 장이 열려있다면 5초마다 SSE로 갱신된 데이터를 받고 있는데 이 5초라는 시간이 개발 단계이기 때문에 5초이지 실 주식 관련 사이트는 1초 미만으로 받고 있다.
- 1초 미만까지 내리는 것을 고려했다면 화면 전체를 계속 리렌더링하는 것은 성능적으로 문제가 있을 수 있다.

## 아쉬운 부분
- api의 형태, 기존에 구현된 테이블 및 컴포넌트들의 구조상 데이터를 받는 부모 컴포넌트가 가지고 있는 wrapper가 계속 렌더링 되게 된다.
- 정확히 바뀌는 값의 element만 리렌더링 시키고 싶지만 api와 컴포넌트 테이블 구조를 모두 손보거나 많이 분할해야 할 것 같아서 현재로는 한계가 있다 판단해서 할 수 있는 최대한으로 리렌더링 범위를 줄였다.

## 전후 비교
#### 우선 이미지는 테스트를 위해 `삼성전자 보통주`의 `현재가` 만 바뀌는 상황을 react dev tools를 활용한 `Highlight updates when components render` 옵션으로 확인한 예시 이미지 입니다

- 전 
![포트폴리오페이지 리랜더1](https://github.com/user-attachments/assets/fb16877d-a1e2-4db4-a2f8-a2e5c869e164)
- 후
![포트폴리오페이지 리랜더2](https://github.com/user-attachments/assets/7887efe2-ded8-41a9-92de-085430976cad)
